### PR TITLE
Deny clippy warnings on ci

### DIFF
--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -51,5 +51,5 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets
+          args: --all-targets -- -D warnings
           name: clippy output


### PR DESCRIPTION
Avoids some lints slipping through. 