### PR TITLE
fix: update conn timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/tools/__pycache__

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Ziggurat implementation for XRPLF's `rippled` nodes.
 5. Run tests with `cargo +stable t -- --test-threads=1`.
 
 ### Initial state
+Specific tests require an initial node state to be set up.
 Follow the steps below to save an initial state that can be loaded later for other tests.
 
 #### Preparation (needs to be done once)
@@ -47,6 +48,13 @@ Follow the steps below to save an initial state that can be loaded later for oth
         "Account": "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
         "Balance": "5000000000",
    ```
-5. Copy the node's files to directory referenced by constant `pub const NODE_STATE_DIR`, currently: `cp -a ~/.ziggurat/ripple/testnet/1 ~/.ziggurat/ripple/stateful`
+5. Copy the node's files to directory referenced by constant `pub const NODE_STATE_DIR`, currently:
+   ```
+   cp -a ~/.ziggurat/ripple/testnet/1/ ~/.ziggurat/ripple/stateful;
+   ```
 6. Now you can stop the test started in step 1.
-7. Remove the config file, it will be created when starting new node: `rm ~/.ziggurat/ripple/stateful/rippled.cfg`
+7. Perform cleanup:
+    ```
+    rm ~/.ziggurat/ripple/stateful/rippled.cfg;   # config file will be created when starting a new node
+    rm -rf ~/.ziggurat/ripple/testnet;            # not needed anymore
+    ```

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 /// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
-pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout when waiting for expected message / node's state.
 pub const EXPECTED_RESULT_TIMEOUT: Duration = Duration::from_secs(20);


### PR DESCRIPTION
- Slower machines (Mac M2, e.g.) require a longer time for node setup.
- Small doc updates.