### PR TITLE
feat: improve unicast tracing

### DIFF
--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -10,7 +10,7 @@ use crate::{
 async fn handshake_when_node_receives_connection() {
     // ZG-CONFORMANCE-001
 
-    // crate::tools::synthetic_node::enable_tracing();
+    // crate::tools::synth_node::enable_tracing();
 
     // Build and start the Ripple node
     let tmp_dir = TempDir::new().expect("Can't build tmp dir");
@@ -36,7 +36,7 @@ async fn handshake_when_node_receives_connection() {
 async fn handshake_when_node_initiates_connection() {
     // ZG-CONFORMANCE-002
 
-    // crate::tools::synthetic_node::enable_tracing();
+    // crate::tools::synth_node::enable_tracing();
 
     // Start synthetic node.
     let synth_node = SyntheticNode::new(&Default::default()).await;

--- a/src/tests/conformance/query/peer_shard_info.rs
+++ b/src/tests/conformance/query/peer_shard_info.rs
@@ -13,6 +13,7 @@ async fn node_should_query_for_shard_info_after_handshake() {
         |m: &BinaryMessage| matches!(&m.payload, Payload::TmGetPeerShardInfoV2(..));
     perform_response_test(Default::default(), &response_check).await;
 }
+
 #[tokio::test]
 #[should_panic]
 async fn node_should_not_query_for_shard_info_if_no_handshake() {

--- a/src/tests/conformance/query/ping_pong.rs
+++ b/src/tests/conformance/query/ping_pong.rs
@@ -1,7 +1,7 @@
 //! Contains test with ping queries.
 //! Queries and expected replies:
 //!
-//!     - mtPING (with PingType::TpPing) -> mtPING (with PingType::PtPong)
+//!     - mtPING (with PingType::PtPing) -> mtPING (with PingType::PtPong)
 
 use rand::{thread_rng, RngCore};
 

--- a/src/tools/inner_node.rs
+++ b/src/tools/inner_node.rs
@@ -14,16 +14,6 @@ use crate::{
     tools::{config::TestConfig, tls_cert},
 };
 
-/// Enables tracing for all [`SyntheticNode`] instances (usually scoped by test).
-pub fn enable_tracing() {
-    use tracing_subscriber::{fmt, EnvFilter};
-
-    fmt()
-        .with_test_writer()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
-}
-
 // A synthetic node adhering to Ripple's network protocol.
 #[derive(Clone)]
 pub struct InnerNode {

--- a/src/tools/synth_node.rs
+++ b/src/tools/synth_node.rs
@@ -11,6 +11,7 @@ use tokio::{
     sync::{mpsc, mpsc::Receiver, oneshot},
     time::timeout,
 };
+use tracing::trace;
 
 use crate::{
     protocol::codecs::binary::{BinaryMessage, Payload},
@@ -20,6 +21,16 @@ use crate::{
         inner_node::InnerNode,
     },
 };
+
+/// Enables tracing for all [`SyntheticNode`] instances (usually scoped by test).
+pub fn enable_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    fmt()
+        .with_test_writer()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+}
 
 pub struct SyntheticNode {
     inner: InnerNode,
@@ -48,6 +59,7 @@ impl SyntheticNode {
         addr: SocketAddr,
         message: Payload,
     ) -> io::Result<oneshot::Receiver<io::Result<()>>> {
+        trace!(parent: self.inner.node().span(), "unicast send msg to {addr}: {:?}", message);
         self.inner.unicast(addr, message)
     }
 


### PR DESCRIPTION
One slight tracing improvement.

I'm thinking of adding one extra trace in the unicast function in the Synth_node implementation,
to print out the message which we are sending on the other side.
Since the below log is not very informative (without this change):
```
2022-09-21T08:55:45.503758Z TRACE tokio_util::codec::framed_impl: writing; remaining=40
2022-09-21T08:55:45.503775Z TRACE tokio_util::codec::framed_impl: framed transport flushed
2022-09-21T08:55:45.503787Z TRACE node{name="0"}: pea2pea::protocols::writing: sent 40B to 127.0.0.1:8080
```

With the change, we get this output:
```
2022-09-21T08:55:45.503675Z TRACE node{name="0"}: ziggurat_xrpl::tools::synth_node: unicast send TmHaveTransactions(TmHaveTransactions { hashes: [[186, 166, 68, 138, 23, 250, 189, 4, 79, 210, 28, 63, 89
, 24, 141, 124, 68, 45, 155, 180, 175, 108, 80, 93, 71, 86, 79, 34, 164, 84, 144, 72]] })

2022-09-21T08:55:45.503750Z TRACE tokio_util::codec::framed_impl: flushing framed transport
2022-09-21T08:55:45.503758Z TRACE tokio_util::codec::framed_impl: writing; remaining=40
2022-09-21T08:55:45.503775Z TRACE tokio_util::codec::framed_impl: framed transport flushed
2022-09-21T08:55:45.503787Z TRACE node{name="0"}: pea2pea::protocols::writing: sent 40B to 127.0.0.1:8080

2022-09-21T08:55:45.504621Z  INFO node{name="0"}: ziggurat_xrpl::protocol::reading: read a message from 127.0.0.1:8080: TmGetObjectByHash(TmGetObjectByHash { r#type: OtTransactions, query: true, seq: No
ne, ledger_hash: None, fat: None, objects: [TmIndexedObject { hash: Some([186, 166, 68, 138, 23, 250, 189, 4, 79, 210, 28, 63, 89, 24, 141, 124, 68, 45, 155, 180, 175, 108, 80, 93, 71, 86, 79, 34, 164,
84, 144, 72]), node_id: None, index: None, data: None, ledger_seq: None }] })
```
This change makes reading logs much easier since now we can see from the logs that the TX we sent to the node
`TmHaveTransactions { hashes: [[186, 166, 68...`
 is the same TX that node is asking us within the
`TmIndexedObject { hash: Some([186, 166, 68...` message

Since I'm a log person 🪵