### PR TITLE
refactor: adhere to new test naming convention

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -14,6 +14,8 @@ For load testing, "reasonable load" and "heavy load" will need to be defined.
 
 The tests can be run with `cargo test` once Ziggurat is properly configured and dependencies (node instance to be tested) are satisfied. See the [README](README.md) for details.
 
+Tests are grouped into the following categories: conformance, performance, and resistance. Each test is named after the category it belongs to, in addition to what's being tested. For example, `c001_handshake_when_node_receives_connection` is the first conformance test and tests the handshake behavior on the receiving end. The full naming convention is: `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
+
 # Types of Tests
 
 ## Conformance
@@ -104,44 +106,37 @@ The test index makes use of symbolic language in describing connection and messa
     <- pong response with the same `sequence` number
 
 ### ZG-CONFORMANCE-004
-    
-    The node responds with mtLEDGER_DATA for mtGET_LEDGER with iType == LiBase.
-    
+
+    The node responds with mtLEDGER_DATA for mtGET_LEDGER with different iType types.
+    iType types used here are LiBase and LiAsNode.
+
     <>
-    -> mtGET_LEDGER with iType == LiBase
+    -> mtGET_LEDGER (iType)
     <- mtLEDGER_DATA
 
 ### ZG-CONFORMANCE-005
-
-    The node responds with mtLEDGER_DATA for mtGET_LEDGER with iType == LiAsNode.
-
-    <>
-    -> mtGET_LEDGER with iType == LiAsNode
-    <- mtLEDGER_DATA
-
-### ZG-CONFORMANCE-006
 
     The node requests mtGET_PEER_SHARD_INFO_V2 after connection and handshake.
 
     <>
     <- mtGET_PEER_SHARD_INFO_V2
 
-### ZG-CONFORMANCE-007
+### ZG-CONFORMANCE-006
 
     The node should *NOT* request mtGET_PEER_SHARD_INFO_V2 after connection if there was no handshake.
     The test waits for the predefined amount of time, ensuring no such messages were received.
 
-### ZG-CONFORMANCE-008
-    
+### ZG-CONFORMANCE-007
+
     The node should respond with transaction details after receiveing TmGetObjectByHash / OtTransactions request.
     Normally the node does not respond with transaction details if the transaction is not in its cache. In this test we first
-    query for transaction details via rpc, then via peer protocol.  
+    query for transaction details via rpc, then via peer protocol.
 
     <>
     -> mtGET_OBJECTS with r#type == OtTransactions
     <- mtTRANSACTIONS
 
-### ZG-CONFORMANCE-009
+### ZG-CONFORMANCE-008
 
     The node should query for the transaction object after receiving a TmHaveTransactions packet.
     <>

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Result;
 use fs_extra::dir::{copy, CopyOptions};
-use tokio::io::AsyncWriteExt;
+use tokio::{io::AsyncWriteExt, net::TcpStream, time::Duration};
 
 use crate::{
     setup::{
@@ -23,11 +23,15 @@ use crate::{
 
 async fn wait_for_start(addr: SocketAddr) {
     tokio::time::timeout(CONNECTION_TIMEOUT, async move {
+        const SLEEP: Duration = Duration::from_millis(10);
+
         loop {
-            if let Ok(mut stream) = tokio::net::TcpStream::connect(addr).await {
+            if let Ok(mut stream) = TcpStream::connect(addr).await {
                 stream.shutdown().await.unwrap();
                 break;
             }
+
+            tokio::time::sleep(SLEEP).await;
         }
     })
     .await

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn handshake_when_node_receives_connection() {
+async fn c001_handshake_when_node_receives_connection() {
     // ZG-CONFORMANCE-001
 
     // crate::tools::synth_node::enable_tracing();
@@ -33,7 +33,7 @@ async fn handshake_when_node_receives_connection() {
 }
 
 #[tokio::test]
-async fn handshake_when_node_initiates_connection() {
+async fn c002_handshake_when_node_initiates_connection() {
     // ZG-CONFORMANCE-002
 
     // crate::tools::synth_node::enable_tracing();

--- a/src/tests/conformance/query/get_by_hash.rs
+++ b/src/tests/conformance/query/get_by_hash.rs
@@ -16,8 +16,9 @@ use crate::{
 };
 
 #[tokio::test]
-async fn should_get_transaction_by_hash() {
-    // ZG-CONFORMANCE-008
+#[allow(non_snake_case)]
+async fn c007_TM_GET_OBJECT_BY_HASH_get_transaction_by_hash() {
+    // ZG-CONFORMANCE-007
     // Create stateful node.
     let target = TempDir::new().expect("unable to create TempDir");
     let mut node = build_stateful_builder(target.path().to_path_buf())
@@ -77,8 +78,9 @@ async fn should_get_transaction_by_hash() {
 }
 
 #[tokio::test]
-async fn should_query_for_transactions_after_have_transactions() {
-    // ZG-CONFORMANCE-009
+#[allow(non_snake_case)]
+async fn c008_TM_HAVE_TRANSACTIONS_query_for_transactions_after_have_transactions() {
+    // ZG-CONFORMANCE-008
     // Create stateful node.
     let target = TempDir::new().expect("unable to create TempDir");
     let mut node = build_stateful_builder(target.path().to_path_buf())

--- a/src/tests/conformance/query/ledger.rs
+++ b/src/tests/conformance/query/ledger.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn should_respond_with_ledger_data_for_basic_info() {
+#[allow(non_snake_case)]
+async fn c004_t1_TM_GET_LEDGER_LiBase_get_basic_info() {
     // ZG-CONFORMANCE-004
     let payload = Payload::TmGetLedger(TmGetLedger {
         itype: TmLedgerInfoType::LiBase as i32,
@@ -29,8 +30,9 @@ async fn should_respond_with_ledger_data_for_basic_info() {
 }
 
 #[tokio::test]
-async fn should_respond_with_ledger_data_for_account_state_info() {
-    // ZG-CONFORMANCE-005
+#[allow(non_snake_case)]
+async fn c004_t2_TM_GET_LEDGER_LiAsNode_get_account_state_info() {
+    // ZG-CONFORMANCE-004
     let payload = Payload::TmGetLedger(TmGetLedger {
         itype: TmLedgerInfoType::LiAsNode as i32,
         ltype: Some(TmLedgerType::LtClosed as i32),

--- a/src/tests/conformance/query/peer_shard_info.rs
+++ b/src/tests/conformance/query/peer_shard_info.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 
 #[tokio::test]
-async fn node_should_query_for_shard_info_after_handshake() {
-    // ZG-CONFORMANCE-006
+#[allow(non_snake_case)]
+async fn c005_TM_GET_PEER_SHARD_INFO_V2_node_should_query_for_shard_info_after_handshake() {
+    // ZG-CONFORMANCE-005
     let response_check =
         |m: &BinaryMessage| matches!(&m.payload, Payload::TmGetPeerShardInfoV2(..));
     perform_response_test(Default::default(), &response_check).await;
@@ -16,8 +17,9 @@ async fn node_should_query_for_shard_info_after_handshake() {
 
 #[tokio::test]
 #[should_panic]
-async fn node_should_not_query_for_shard_info_if_no_handshake() {
-    // ZG-CONFORMANCE-007
+#[allow(non_snake_case)]
+async fn c006_TM_GET_PEER_SHARD_INFO_V2_node_should_not_query_for_shard_info_if_no_handshake() {
+    // ZG-CONFORMANCE-006
     let response_check =
         |m: &BinaryMessage| matches!(&m.payload, Payload::TmGetPeerShardInfoV2(..));
     perform_response_test(TestConfig::default().with_handshake(false), &response_check).await;

--- a/src/tests/conformance/query/ping_pong.rs
+++ b/src/tests/conformance/query/ping_pong.rs
@@ -15,7 +15,8 @@ use crate::{
 };
 
 #[tokio::test]
-async fn should_respond_with_pong_for_ping() {
+#[allow(non_snake_case)]
+async fn c003_TM_PING_expect_pong() {
     // ZG-CONFORMANCE-003
     // Send `ping` message
     let seq = thread_rng().next_u32();

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 /// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
-pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Timeout when waiting for expected message / node's state.
 pub const EXPECTED_RESULT_TIMEOUT: Duration = Duration::from_secs(20);


### PR DESCRIPTION
- Tests are grouped into the following categories: conformance, performance, and resistance. Each test is named after the category it belongs to, in addition to what's being tested. For example, `c001_handshake_when_node_receives_connection` is the first conformance test and tests the handshake behaviour on the receiving end. The full naming convention is: `id_part_t(subtest_no)_(message type)_(extra_test_desc)`.
- SPEC.md updated accordingly