### PR TITLE
feat: add c009 test for the mtSQUELCH message

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -142,3 +142,11 @@ The test index makes use of symbolic language in describing connection and messa
     <>
     -> mtHAVE_TRANSACTIONS
     <- TmGetObjectByHash
+
+### ZG-CONFORMANCE-009
+
+    The node should ignore the squelch message for its validator public key.
+    <>
+    <- mtPROPOSE_LEDGER with node's node_pub_key
+    -> mtSQUELCH (node_pub_key)
+    <- mtPROPOSE_LEDGER with node's node_pub_key

--- a/src/protocol/codecs/binary.rs
+++ b/src/protocol/codecs/binary.rs
@@ -56,6 +56,7 @@ pub enum Payload {
     TmHaveSet(TmHaveTransactionSet),
     TmValidation(TmValidation),
     TmGetObjectByHash(TmGetObjectByHash),
+    TmSquelch(TmSquelch),
     TmValidatorListCollection(TmValidatorListCollection),
     TmGetPeerShardInfoV2(TmGetPeerShardInfoV2),
     TmTransactions(TmTransactions),
@@ -209,6 +210,7 @@ impl Decoder for BinaryCodec {
                 35 => Payload::TmHaveSet(Message::decode(&mut payload)?),
                 41 => Payload::TmValidation(Message::decode(&mut payload)?),
                 42 => Payload::TmGetObjectByHash(Message::decode(&mut payload)?),
+                55 => Payload::TmSquelch(Message::decode(&mut payload)?),
                 56 => Payload::TmValidatorListCollection(Message::decode(&mut payload)?),
                 61 => Payload::TmGetPeerShardInfoV2(Message::decode(&mut payload)?),
                 63 => Payload::TmHaveTransactions(Message::decode(&mut payload)?),
@@ -270,6 +272,7 @@ impl Encoder<Payload> for BinaryCodec {
             Payload::TmGetObjectByHash(msg) => {
                 (msg.encoded_len() as u32, MessageType::MtGetObjects as i32)
             }
+            Payload::TmSquelch(msg) => (msg.encoded_len() as u32, MessageType::MtSquelch as i32),
             Payload::TmHaveSet(msg) => (msg.encoded_len() as u32, MessageType::MtHaveSet as i32),
             Payload::TmValidatorListCollection(msg) => (
                 msg.encoded_len() as u32,
@@ -320,6 +323,7 @@ impl Encoder<Payload> for BinaryCodec {
             Payload::TmStatusChange(msg) => (msg.encode(&mut bytes).unwrap(),),
             Payload::TmValidation(msg) => (msg.encode(&mut bytes).unwrap(),),
             Payload::TmGetObjectByHash(msg) => (msg.encode(&mut bytes).unwrap(),),
+            Payload::TmSquelch(msg) => (msg.encode(&mut bytes).unwrap(),),
             Payload::TmHaveSet(msg) => (msg.encode(&mut bytes).unwrap(),),
             Payload::TmValidatorListCollection(msg) => (msg.encode(&mut bytes).unwrap(),),
             Payload::TmGetPeerShardInfoV2(msg) => (msg.encode(&mut bytes).unwrap(),),

--- a/src/tests/conformance/mod.rs
+++ b/src/tests/conformance/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 
 mod handshake;
 mod query;
+mod squelch;
 mod stateful;
 
 async fn perform_response_test(

--- a/src/tests/conformance/squelch.rs
+++ b/src/tests/conformance/squelch.rs
@@ -1,0 +1,116 @@
+//! Contains test for the squelching functionality.
+//!
+//! Node can select a subset of its peers to function as the source of proposal and validation messages from a
+//! specific validator and suppressing the messages from the rest of its peers by sending a “squelch” message to them.
+//!
+//! More specifically, the “squelch” message tells a peer to suppress messages originating from a
+//! certain validator (identified by a public key) for a given amount of time. After the duration
+//! expires, the peer starts relaying messages downstream.
+//!
+//! Squelching a connected peer which is also a validator is not possible in case when messages
+//! originate from that peer.
+//!
+//!     <- mtPROPOSE_LEDGER (validator1)
+//!     <- mtPROPOSE_LEDGER (validator2)
+//!     <- mtPROPOSE_LEDGER (validator1)
+//!     <- mtPROPOSE_LEDGER (validator2)
+//!     -> mtSQUELCH (validator1)
+//!     <-
+//!     <- mtPROPOSE_LEDGER (validator2)
+//!     <-
+//!     <- mtPROPOSE_LEDGER (validator2)
+
+use tempfile::TempDir;
+use tokio::time::{sleep, timeout, Duration};
+
+use crate::{
+    protocol::{
+        codecs::binary::{BinaryMessage, Payload},
+        proto::{TmProposeSet, TmSquelch},
+    },
+    setup::node::build_stateful_builder,
+    tools::{rpc::wait_for_state, synth_node::SyntheticNode},
+};
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c009_TM_SQUELCH_cannot_squelch_peer_ledger_proposals() {
+    // ZG-CONFORMANCE-009
+
+    // Time we shall wait for a TmProposeLedger message.
+    const WAIT_MSG_TIMEOUT: Duration = Duration::from_secs(10);
+    const SQUELCH_DURATION: u32 = 6 * 60; // Six minutes should be an ample time value.
+    const HANDLE_REMAINING_PROPOSE_MSGS: Duration = Duration::from_millis(300);
+
+    // Create a stateful node.
+    let target = TempDir::new().expect("unable to create TempDir");
+    let mut node = build_stateful_builder(target.path().to_path_buf())
+        .expect("unable to get stateful builder")
+        .start(true)
+        .await
+        .expect("unable to start stateful node");
+
+    // Wait for correct state and account data.
+    wait_for_state("proposing".into()).await;
+
+    // Connect synth node.
+    let mut synth_node = SyntheticNode::new(&Default::default()).await;
+    synth_node
+        .connect(node.addr())
+        .await
+        .expect("unable to connect");
+
+    // Get a validator public key.
+    let mut validator_pub_key: Vec<u8> = Vec::new();
+    timeout(WAIT_MSG_TIMEOUT, async {
+        loop {
+            if let (
+                _,
+                BinaryMessage {
+                    payload: Payload::TmProposeLedger(TmProposeSet { node_pub_key, .. }),
+                    ..
+                },
+            ) = synth_node.recv_message().await
+            {
+                validator_pub_key = node_pub_key;
+                break;
+            }
+        }
+    })
+    .await
+    .expect("TmProposeLedger not received in time");
+
+    // Squelch the validator public key belonging to our only neighbour.
+    let msg = Payload::TmSquelch(TmSquelch {
+        squelch: true,
+        validator_pub_key: validator_pub_key.clone(),
+        squelch_duration: Some(SQUELCH_DURATION),
+    });
+    synth_node.unicast(node.addr(), msg).unwrap();
+
+    // Ensure all incoming TmProposeLedger messages are handled before the node processes the squelch message.
+    sleep(HANDLE_REMAINING_PROPOSE_MSGS).await;
+
+    // Check that the squelch message had no effect and that we will continue to receive TmProposeLedger messages from the node.
+    timeout(WAIT_MSG_TIMEOUT, async {
+        loop {
+            if let (
+                _,
+                BinaryMessage {
+                    payload: Payload::TmProposeLedger(TmProposeSet { node_pub_key, .. }),
+                    ..
+                },
+            ) = synth_node.recv_message().await
+            {
+                if validator_pub_key == node_pub_key {
+                    break;
+                }
+            }
+        }
+    })
+    .await
+    .expect("TmProposeLedger not received in time");
+
+    synth_node.shut_down().await;
+    node.stop().expect("unable to stop stateful node");
+}


### PR DESCRIPTION
Here are the most important bits from the logs:

```
2022-09-26T20:56:40.950339Z DEBUG node{name="0"}: ziggurat_xrpl::protocol::reading: sending the message to the node's inbound queue
2022-09-26T20:56:40.950504Z TRACE node{name="0"}: ziggurat_xrpl::tools::synth_node: unicast send msg to 127.0.0.1:8080: TmSquelch(TmSquelch { squelch: true, validator_pub_key: [2, 244, 117, 76, 27, 51,
199, 211, 46, 128, 94, 178, 177, 135, 0, 154, 155, 67, 18, 68, 30, 145, 152, 131, 76, 91, 155, 99, 110, 45, 149, 84, 185], squelch_duration: Some(360) })
2022-09-26T20:56:40.950772Z TRACE tokio_util::codec::framed_impl: flushing framed transport
2022-Sep-26 20:56:40.950794 UTC Peer:DBG [007] Connect 34.221.145.175:51235
2022-09-26T20:56:40.950804Z TRACE tokio_util::codec::framed_impl: writing; remaining=46
2022-09-26T20:56:40.950924Z TRACE tokio_util::codec::framed_impl: framed transport flushed
2022-09-26T20:56:40.950974Z TRACE node{name="0"}: pea2pea::protocols::writing: sent 46B to 127.0.0.1:8080
2022-Sep-26 20:56:40.951115 UTC Resource:DBG New outbound endpoint 3.122.10.154:51235
2022-Sep-26 20:56:40.951155 UTC PeerFinder:DBG Logic connect     3.122.10.154:51235
2022-Sep-26 20:56:40.951609 UTC Protocol:DBG [001] onMessage: TMSquelch discarding validator's squelch 02F4754C1B33C7D32E805EB2B187009A9B4312441E9198834C5B9B636E2D9554B9

2022-09-26T20:56:43.962734Z  INFO node{name="0"}: ziggurat_xrpl::protocol::reading: read a message from 127.0.0.1:8080: TmProposeLedger(TmProposeSet { propose_seq: 0, current_tx_hash: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], node_pub_key: [2, 244, 117, 76, 27, 51, 199, 211, 46, 128, 94, 178, 177, 135, 0, 154, 155, 67, 18, 68, 30, 145, 152, 131, 76, 91, 155, 99, 110, 45, 149, 84, 185], close_time: 717541003, signature: [48, 68, 2, 32, 112, 59, 19, 144, 150, 162, 84, 201, 38, 67, 97, 95, 214, 140, 56, 78, 13, 151, 187, 130, 118, 168, 78, 238, 117, 139, 118, 73, 150, 141, 222, 155, 2, 32, 127, 83, 166, 171, 1, 96, 66, 126, 207, 130, 216, 175, 25, 149, 90, 205, 127, 5, 248, 70, 48, 123, 193, 202, 7, 119, 67, 198, 217, 217, 255, 24], previousledger: [170, 1, 146, 76, 134, 124, 254, 119, 12, 78, 179, 212, 73, 4, 66, 169, 155, 7, 121, 171, 243, 54, 65, 11, 213, 71, 48, 26, 38, 75,2022-Sep-26 20:56:43.962959 UTC PeerFinder:DBG Logic waiting on  5 attempts
 66, 247], added_transactions: [], removed_transactions: [], checked_signature: None, hops: None })
2022-09-26T20:56:43.963279Z DEBUG node{name="0"}: ziggurat_xrpl::protocol::reading: sending the message to the node's inbound queue
2022-09-26T20:56:43.963506Z DEBUG node{name="0"}: pea2pea::node: shutting down
2022-09-26T20:56:43.963648Z DEBUG node{name="0"}: pea2pea::node: disconnecting from 127.0.0.1:8080
2022-09-26T20:56:43.963703Z DEBUG node{name="0"}: pea2pea::node: disconnected from 127.0.0.1:8080
ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 5.18s
```