### PR TITLE
chore: centralize setup constants

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -1,3 +1,5 @@
+//! Utilities for node configuration.
+
 use std::{
     ffi::OsString,
     fmt::Write,
@@ -8,29 +10,10 @@ use std::{
 use anyhow::Result;
 use serde::Deserialize;
 
-use crate::{setup::node::NodeConfig, tools::constants::VALIDATORS_FILE_NAME};
-
-/// Ziggurat's configuration directory.
-pub const ZIGGURAT_DIR: &str = ".ziggurat";
-
-/// Ziggurat's Ripple's subdir.
-pub const RIPPLE_WORK_DIR: &str = "ripple";
-
-/// Initial setup dir for rippled.
-pub const RIPPLE_SETUP_DIR: &str = "setup";
-
-/// Directory containing saved ledger and config to be loaded after the start.
-pub const STATEFUL_NODES_DIR: &str = "stateful";
-
-/// Configuration file with paths to start rippled.
-pub const ZIGGURAT_CONFIG: &str = "config.toml";
-
-/// Rippled's configuration file name.
-pub const RIPPLED_CONFIG: &str = "rippled.cfg";
-pub const RIPPLED_DIR: &str = "rippled";
-
-/// Rippled's JSON RPC port
-pub const JSON_RPC_PORT: u32 = 5005;
+use crate::setup::{
+    constants::{JSON_RPC_PORT, RIPPLED_DIR, VALIDATORS_FILE_NAME, ZIGGURAT_CONFIG},
+    node::NodeConfig,
+};
 
 /// Convenience struct for reading Ziggurat's configuration file.
 #[derive(Deserialize)]

--- a/src/setup/constants.rs
+++ b/src/setup/constants.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+/// Ziggurat's configuration directory.
+pub const ZIGGURAT_DIR: &str = ".ziggurat";
+
+/// Ziggurat's Ripple's subdir.
+pub const RIPPLE_WORK_DIR: &str = "ripple";
+
+/// Initial setup dir for rippled.
+pub const RIPPLE_SETUP_DIR: &str = "setup";
+
+/// Configuration file with paths to start rippled.
+pub const ZIGGURAT_CONFIG: &str = "config.toml";
+
+/// Validators file name.
+pub const VALIDATORS_FILE_NAME: &str = "validators.txt";
+
+/// Directory containing saved ledger and config to be loaded after the start.
+pub const STATEFUL_NODES_DIR: &str = "stateful";
+
+/// Number of available stateful nodes
+pub const STATEFUL_NODES_COUNT: usize = 3;
+
+/// Validator IP address list
+pub const VALIDATOR_IPS: [&str; STATEFUL_NODES_COUNT] = ["127.0.0.1", "127.0.0.2", "127.0.0.3"];
+
+/// Rippled's configuration file name.
+pub const RIPPLED_CONFIG: &str = "rippled.cfg";
+pub const RIPPLED_DIR: &str = "rippled";
+
+/// Rippled's JSON RPC port
+pub const JSON_RPC_PORT: u32 = 5005;
+
+/// The default port to start a Rippled node on.
+pub const DEFAULT_PORT: u16 = 8080;
+
+/// [TestNet](crate::setup::testnet::TestNet)'s network id. The number here doesn't have any significance, but cannot be 0 nor 255.
+pub const TESTNET_NETWORK_ID: u32 = 239048;
+
+/// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,10 +1,11 @@
-//! Utilities for setting up and tearing down node Ripple node instances.
+//! Utilities for setting up and tearing down Ripple node instances.
 
 use std::{io, path::PathBuf};
 
-use crate::setup::config::{RIPPLE_WORK_DIR, ZIGGURAT_DIR};
+use crate::setup::constants::{RIPPLE_WORK_DIR, ZIGGURAT_DIR};
 
 pub mod config;
+pub mod constants;
 pub mod node;
 pub mod testnet;
 

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -10,19 +10,15 @@ use anyhow::Result;
 use fs_extra::{dir, file};
 use tokio::{io::AsyncWriteExt, net::TcpStream, time::Duration};
 
-use crate::{
-    setup::{
-        build_ripple_work_path,
-        config::{
-            NodeMetaData, RippledConfigFile, JSON_RPC_PORT, RIPPLED_CONFIG, RIPPLE_SETUP_DIR,
-            STATEFUL_NODES_DIR,
-        },
-        testnet::{get_validator_token, VALIDATOR_IPS},
+use crate::setup::{
+    build_ripple_work_path,
+    config::{NodeMetaData, RippledConfigFile},
+    constants::{
+        CONNECTION_TIMEOUT, DEFAULT_PORT, JSON_RPC_PORT, RIPPLED_CONFIG, RIPPLE_SETUP_DIR,
+        STATEFUL_NODES_COUNT, STATEFUL_NODES_DIR, TESTNET_NETWORK_ID, VALIDATORS_FILE_NAME,
+        VALIDATOR_IPS,
     },
-    tools::constants::{
-        CONNECTION_TIMEOUT, DEFAULT_PORT, STATEFUL_NODES_COUNT, TESTNET_NETWORK_ID,
-        VALIDATORS_FILE_NAME,
-    },
+    testnet::get_validator_token,
 };
 
 async fn wait_for_start(addr: SocketAddr) {

--- a/src/setup/testnet/mod.rs
+++ b/src/setup/testnet/mod.rs
@@ -8,14 +8,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{
-    setup::{
-        build_ripple_work_path,
-        node::{Node, NodeBuilder, NodeType},
+use crate::setup::{
+    build_ripple_work_path,
+    constants::{
+        DEFAULT_PORT, STATEFUL_NODES_COUNT, TESTNET_NETWORK_ID, VALIDATORS_FILE_NAME, VALIDATOR_IPS,
     },
-    tools::constants::{
-        DEFAULT_PORT, STATEFUL_NODES_COUNT, TESTNET_NETWORK_ID, VALIDATORS_FILE_NAME,
-    },
+    node::{Node, NodeBuilder, NodeType},
 };
 
 /// Testnet's directory for nodes' configs.
@@ -26,9 +24,6 @@ const VALIDATOR_KEYS: [&str; STATEFUL_NODES_COUNT] = [
     "nHUEsvSFTf1Snr7ZUdLxjcMW6PKcMrwwXCGZBg6xb1ePG8R4C3TS",
     "nHUuYdS49cPfRmCXPTwu7MVVFZFFmfG7y5sRttirVMhwuD7xStQp",
 ];
-
-/// Validator IP address list
-pub const VALIDATOR_IPS: [&str; STATEFUL_NODES_COUNT] = ["127.0.0.1", "127.0.0.2", "127.0.0.3"];
 
 /// Get validator token.
 pub fn get_validator_token(stateful_node_idx: usize) -> String {

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -1,8 +1,11 @@
 use tempfile::TempDir;
 
 use crate::{
-    setup::node::{Node, NodeType},
-    tools::{constants::CONNECTION_TIMEOUT, synth_node::SyntheticNode},
+    setup::{
+        constants::CONNECTION_TIMEOUT,
+        node::{Node, NodeType},
+    },
+    tools::synth_node::SyntheticNode,
     wait_until,
 };
 

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -1,22 +1,7 @@
 use std::time::Duration;
 
-/// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
-pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Timeout when waiting for expected message / node's state.
 pub const EXPECTED_RESULT_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Channel buffer bound for [InnerNode](crate::tools::inner_node::InnerNode) -> [SyntheticNode](crate::tools::synth_node::SyntheticNode) messages.
 pub const SYNTH_NODE_QUEUE_DEPTH: usize = 100;
-
-/// [TestNet](crate::setup::testnet::TestNet)'s network id. The number here doesn't have any significance, but cannot be 0 nor 255.
-pub const TESTNET_NETWORK_ID: u32 = 239048;
-
-/// The default port to start a Rippled node on.
-pub const DEFAULT_PORT: u16 = 8080;
-
-/// Validators file name.
-pub const VALIDATORS_FILE_NAME: &str = "validators.txt";
-
-/// Number of available stateful nodes
-pub const STATEFUL_NODES_COUNT: usize = 3;


### PR DESCRIPTION
- Constants belonging to the setup directory structure should be placed in setup/constants.rs
- Constants belonging to tools and tests directory structures should be placed in tools/constants.rs