### PR TITLE
chore: always serve the first stateful node first

### DIFF
--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -58,12 +58,12 @@ pub enum NodeType {
 }
 
 pub struct NodeBuilder {
-    /// Node's startup configuration
+    /// Node's startup configuration.
     conf: NodeConfig,
-    /// Node's process metadata read from Ziggurat configuration files
+    /// Node's process metadata read from Ziggurat configuration files.
     meta: NodeMetaData,
-    /// Pool of available stateful node indices which represent stateful nodes' directories
-    stateful_nodes_pool: usize,
+    /// Counter for served stateful nodes.
+    stateful_nodes_counter: usize,
 }
 
 impl NodeBuilder {
@@ -77,7 +77,7 @@ impl NodeBuilder {
         Ok(Self {
             conf,
             meta,
-            stateful_nodes_pool: STATEFUL_NODES_COUNT,
+            stateful_nodes_counter: 0,
         })
     }
 
@@ -98,12 +98,13 @@ impl NodeBuilder {
 
         match node_type {
             NodeType::Stateful => {
-                let node_idx = if self.stateful_nodes_pool != 0 {
-                    self.stateful_nodes_pool -= 1;
-                    self.stateful_nodes_pool
-                } else {
-                    panic!("Not enough stateful nodes available");
-                };
+                let node_idx = self.stateful_nodes_counter;
+                self.stateful_nodes_counter += 1;
+                assert!(
+                    self.stateful_nodes_counter <= STATEFUL_NODES_COUNT,
+                    "Not enough stateful nodes available"
+                );
+
                 let source = get_stateful_node_path(node_idx)?;
 
                 let mut copy_options = dir::CopyOptions::new();

--- a/src/tests/conformance/query/peer_shard_info.rs
+++ b/src/tests/conformance/query/peer_shard_info.rs
@@ -120,5 +120,5 @@ async fn check_relay_for_key_type(key_type: u8, relays: u32) {
     // Shutdown.
     synth_node1.shut_down().await;
     synth_node2.shut_down().await;
-    node.stop().expect("unable to stop rippled node");
+    node.stop().expect("unable to stop the rippled node");
 }


### PR DESCRIPTION
- For some reason, stateful nodes 'node1' and 'node2' cannot reach a 'proposing.' server_state on Linux. Only 'node0' is capable of reaching the 'proposing.' state. That strange behaviour should be investigated further.