### PR TITLE
feat: add c016 for the mtSQUELCH message

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -202,3 +202,19 @@ The test index makes use of symbolic language in describing connection and messa
     with a correct public key and a non-empty manifest.
     <>
     <- TmValidatorListCollection with at least one validator with a correct public key and a non-empty manifest.
+
+### ZG-CONFORMANCE-016
+
+    Deploy a network of three nodes: Node 1, Node 2 and Node 3.
+    Connect a synthetic node to Node 1.
+    After squelching validator keys belonging to Node 2 and Node 3,
+    Node 1 shouldn't broadcast mtPROPOSE_LEDGER messages from squelched validators to the synthetic node.
+    <> with Node1
+    <- mtPROPOSE_LEDGER with the Node 1's node_pub_key1
+    <- mtPROPOSE_LEDGER with the Node 2's node_pub_key2
+    <- mtPROPOSE_LEDGER with the Node 3's node_pub_key3
+    -> mtSQUELCH (node_pub_key2)
+    -> mtSQUELCH (node_pub_key3)
+    <- mtPROPOSE_LEDGER with the Node 1's node_pub_key1
+    <- mtPROPOSE_LEDGER with the Node 1's node_pub_key1
+    <- mtPROPOSE_LEDGER with the Node 1's node_pub_key1

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -301,6 +301,7 @@ mod test {
     const SLEEP: Duration = Duration::from_millis(100);
 
     #[tokio::test]
+    #[ignore = "use only when changing src/setup files"]
     async fn run_stateless_nodes_in_parallel() {
         let mut builder = NodeBuilder::stateless().expect("Can't build a stateless node");
         let mut nodes = Vec::<Node>::with_capacity(STATELESS_NODE_CNT);
@@ -323,6 +324,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "use only when changing src/setup files"]
     async fn run_stateless_nodes_sequentially() {
         let mut builder = NodeBuilder::stateless().expect("Can't build a stateless node");
 
@@ -340,6 +342,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "use only when changing src/setup files"]
     async fn run_stateful_nodes_sequentially() {
         let mut builder = NodeBuilder::stateful().expect("Can't build a stateful node");
 
@@ -357,6 +360,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "use only when changing src/setup files"]
     #[should_panic]
     async fn run_too_many_stateful_nodes_sequentially() {
         let mut builder = NodeBuilder::stateful().expect("Can't build a stateful node");
@@ -374,6 +378,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore = "use only when changing src/setup files"]
     async fn run_stateful_nodes_in_parallel() {
         let mut builder = NodeBuilder::stateful().expect("Can't build a stateful node");
         let mut nodes = Vec::<Node>::with_capacity(STATEFUL_NODES_COUNT);

--- a/src/tests/conformance/cmd/squelch.rs
+++ b/src/tests/conformance/cmd/squelch.rs
@@ -28,7 +28,10 @@ use crate::{
         codecs::binary::{BinaryMessage, Payload},
         proto::{TmProposeSet, TmSquelch},
     },
-    setup::node::{Node, NodeType},
+    setup::{
+        constants::STATEFUL_NODES_COUNT,
+        node::{Node, NodeType},
+    },
     tools::{rpc::wait_for_state, synth_node::SyntheticNode},
 };
 
@@ -95,6 +98,117 @@ async fn c009_TM_SQUELCH_cannot_squelch_peer_ledger_proposals() {
 
     synth_node.shut_down().await;
     node.stop().expect("Unable to stop the stateful node");
+}
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c016_TM_SQUELCH_squelch_distant_validators() {
+    // ZG-CONFORMANCE-016
+
+    const DISTANT_NODES_CNT: usize = STATEFUL_NODES_COUNT - 1;
+
+    // We need to keep alive these temp directories for the whole duration of the test.
+    let target_dirs = (0..STATEFUL_NODES_COUNT)
+        .map(|_| TempDir::new().expect("Couldn't create a temporary directory"))
+        .collect::<Vec<TempDir>>();
+    let mut target = target_dirs.iter();
+
+    let mut builder = Node::builder();
+
+    // Create a stateful node that will be our synth node's only peer.
+    let mut peer_node = builder
+        .start(target.next().unwrap().path(), NodeType::Stateful)
+        .await
+        .expect("Unable to start the stateful node");
+
+    // Wait for correct state and account data.
+    wait_for_state(&peer_node.rpc_url(), "proposing".into()).await;
+
+    // Connect a synth node.
+    let mut synth_node = SyntheticNode::new(&Default::default()).await;
+    synth_node
+        .connect(peer_node.addr())
+        .await
+        .expect("Unable to connect");
+
+    // Get a validator public key from the only running node.
+    let peer_node_validator_key: Vec<u8> =
+        wait_for_validator_key_in_propose_msg(&mut synth_node).await;
+
+    // Prepare other nodes which are all mutually connected but not with the synth node.
+    let mut peer_addr_list = vec![peer_node.addr()];
+    let mut distant_nodes = vec![];
+    for _ in 0..DISTANT_NODES_CNT {
+        builder = builder
+            .log_to_stdout(false) // Explicit configuration until we really need to debug these nodes.
+            .initial_peers(peer_addr_list.clone());
+        let node = builder
+            .start(target.next().unwrap().path(), NodeType::Stateful)
+            .await
+            .expect("Unable to start the stateful node");
+
+        peer_addr_list.push(node.addr());
+        distant_nodes.push(node);
+    }
+
+    // Collect validation keys for distant nodes.
+    let mut distant_node_keys = vec![];
+    timeout(WAIT_MSG_TIMEOUT, async {
+        loop {
+            let node_pub_key = wait_for_validator_key_in_propose_msg(&mut synth_node).await;
+            if node_pub_key == peer_node_validator_key {
+                continue;
+            }
+
+            if !distant_node_keys.contains(&node_pub_key) {
+                distant_node_keys.push(node_pub_key);
+                if distant_node_keys.len() == DISTANT_NODES_CNT {
+                    break;
+                }
+            }
+        }
+    })
+    .await
+    .expect("TmProposeLedger not received in time");
+
+    // Squelch distant nodes.
+    for key in distant_node_keys.iter() {
+        let msg = Payload::TmSquelch(TmSquelch {
+            squelch: true,
+            validator_pub_key: key.clone(),
+            squelch_duration: Some(SQUELCH_DURATION_SECS),
+        });
+        synth_node.unicast(peer_node.addr(), msg).unwrap();
+    }
+
+    // Ensure all incoming TmProposeLedger messages are handled before nodes process the squelch message.
+    sleep(HANDLE_REMAINING_PROPOSE_MSGS).await;
+
+    // Verify we are not receiving TmProposeLedger messages from distant nodes.
+    let expect_timeout_err_for_squelched_nodes = timeout(WAIT_MSG_TIMEOUT, async {
+        loop {
+            if let (
+                _,
+                BinaryMessage {
+                    payload: Payload::TmProposeLedger(TmProposeSet { node_pub_key, .. }),
+                    ..
+                },
+            ) = synth_node.recv_message().await
+            {
+                if distant_node_keys.contains(&node_pub_key) {
+                    panic!("It shouldn't be possible to receive proposing ledgers from squelched nodes.");
+                }
+            }
+        }
+    }).await;
+
+    assert!(expect_timeout_err_for_squelched_nodes.is_err());
+
+    synth_node.shut_down().await;
+    peer_node.stop().expect("Unable to stop the stateful node");
+    for mut node in distant_nodes {
+        node.stop().expect("Unable to stop the stateful node");
+    }
 }
 
 async fn wait_for_validator_key_in_propose_msg(synth_node: &mut SyntheticNode) -> Vec<u8> {


### PR DESCRIPTION
- Ensure squelching works correctly in a multi-node network environment. A synthetic node should be able to squelch distant validators.
- SPEC.md updated accordingly