### PR TITLE
Feature: test for mt transaction message

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -230,3 +230,11 @@ The test index makes use of symbolic language in describing connection and messa
     The node sends mtENDPOINTS after the handshake.
     <>
     <- mtENDPOINTS
+
+### ZG-CONFORMANCE-019
+
+    Nodes in the testnet should relay a mtTRANSACTION message to connected peers.
+    Connection scenario:
+    RPC call > Rippled 1 <> Rippled 2 <> Synthetic Node 
+    This test checks whether the synthetic node receives the mtTRANSACTION 
+    message containing details from the RPC call.    

--- a/src/setup/constants.rs
+++ b/src/setup/constants.rs
@@ -39,3 +39,6 @@ pub const TESTNET_NETWORK_ID: u32 = 239048;
 
 /// Timeout when waiting for [Node](crate::setup::node::Node)'s start.
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Timeout when waiting for [TestNet](crate::setup::testnet::TestNet) to start.
+pub const TESTNET_READY_TIMEOUT: Duration = Duration::from_secs(60);

--- a/src/setup/testnet/mod.rs
+++ b/src/setup/testnet/mod.rs
@@ -40,7 +40,7 @@ pub struct TestNet {
     // Setup information for each node. Used for writing configuration.
     pub setups: [NodeSetup; VALIDATOR_KEYS.len()],
     // Running nodes. Used to stop the testnet.
-    running: Vec<Node>,
+    pub running: Vec<Node>,
     // Sets whether to log the node's output to Ziggurat's output stream.
     use_stdout: bool,
     // Path under which all nodes will be built

--- a/src/tests/conformance/cmd/mod.rs
+++ b/src/tests/conformance/cmd/mod.rs
@@ -1,2 +1,3 @@
 mod squelch;
+mod transaction;
 mod validators;

--- a/src/tests/conformance/cmd/transaction.rs
+++ b/src/tests/conformance/cmd/transaction.rs
@@ -1,0 +1,59 @@
+use crate::{
+    protocol::{
+        codecs::binary::{BinaryMessage, Payload},
+        proto::TransactionStatus::TsCurrent,
+    },
+    setup::{constants::TESTNET_READY_TIMEOUT, testnet::TestNet},
+    tools::{
+        rpc::{submit_transaction, wait_for_account_data},
+        synth_node::SyntheticNode,
+    },
+};
+
+#[tokio::test]
+#[allow(non_snake_case)]
+async fn c019_MT_TRANSACTION_node_should_broadcast_transaction_to_all_peers() {
+    // ZG-CONFORMANCE-019
+    const NODE_IDS: [usize; 2] = [0, 1];
+    // A transaction blob representing a signed transaction. Extracted by executing `tools/transfer.py` and listening with `tcpdump -A -i lo dst port 5005 or src port 5005`.
+    const TRANSACTION_BLOB: &str = "12000022000000002400000001201B0000001E61400000012A05F20068400000000000000A73210330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020744630440220297389244D36AF12115296F409C446D9A5D808880DC7FF323AA207ED529CE6C802207AAC5D2A96CB102CBDE85D2A4BA814253CA133AC9277041CAE2E1A349FB233FF8114B5F762798A53D543A014CAF8B297CFF8F2F937E883149193D6AED0CBBC25790ADE05D020C9C6D9201DCF";
+
+    // Start a testnet.
+    let mut testnet = TestNet::new().unwrap();
+    testnet.start().await.unwrap();
+    wait_for_account_data(
+        &testnet.running[NODE_IDS[0]].rpc_url(),
+        "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        TESTNET_READY_TIMEOUT,
+    )
+    .await
+    .expect("Unable to get the account data.");
+
+    // Start a synthetic node and connect to the second node in the testnet.
+    let mut synth_node = SyntheticNode::new(&Default::default()).await;
+    synth_node
+        .connect(testnet.running[NODE_IDS[1]].addr())
+        .await
+        .expect("Unable to connect to the second node");
+
+    // Submit a transaction to the first node via RPC.
+    let blob_bytes = hex::decode(TRANSACTION_BLOB).unwrap();
+    let transaction = submit_transaction(
+        &testnet.running[NODE_IDS[0]].rpc_url(),
+        TRANSACTION_BLOB.into(),
+        false,
+    )
+    .await
+    .expect("Unable to submit the transaction.");
+    assert!(transaction.result.accepted);
+    assert!(transaction.result.applied);
+    assert!(transaction.result.broadcast);
+
+    // Ensure that the synthetic node connected to the second node received the transaction.
+    let check = |m: &BinaryMessage| matches!(&m.payload, Payload::TmTransaction(tm_transaction) if tm_transaction.raw_transaction == blob_bytes && tm_transaction.status == TsCurrent as i32 && tm_transaction.deferred == Some(false));
+    assert!(synth_node.expect_message(&check).await);
+
+    // Shutdown.
+    testnet.stop().await.expect("Unable to stop the testnet.");
+    synth_node.shut_down().await;
+}

--- a/src/tests/conformance/query/get_by_hash.rs
+++ b/src/tests/conformance/query/get_by_hash.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     setup::node::{Node, NodeType},
     tools::{
+        constants::EXPECTED_RESULT_TIMEOUT,
         rpc::{get_transaction_info, wait_for_account_data, wait_for_state},
         synth_node::SyntheticNode,
     },
@@ -29,9 +30,13 @@ async fn c007_TM_GET_OBJECT_BY_HASH_get_transaction_by_hash() {
 
     // Wait for correct state and account data.
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
-    let account_data = wait_for_account_data(&node.rpc_url(), "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt") // TODO make constant
-        .await
-        .expect("unable to get account data");
+    let account_data = wait_for_account_data(
+        &node.rpc_url(),
+        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
+        EXPECTED_RESULT_TIMEOUT,
+    ) // TODO make constant
+    .await
+    .expect("unable to get account data");
 
     // Get transaction info by rpc to put in cache.
     let tx = account_data.result.account_data.previous_transaction;
@@ -94,9 +99,13 @@ async fn c008_TM_HAVE_TRANSACTIONS_query_for_transactions_after_have_transaction
     // Wait for correct state and account data.
     // TODO Add enum to represent node's states.
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
-    let account_data = wait_for_account_data(&node.rpc_url(), "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt") // TODO make constant
-        .await
-        .expect("unable to get account data");
+    let account_data = wait_for_account_data(
+        &node.rpc_url(),
+        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
+        EXPECTED_RESULT_TIMEOUT,
+    ) // TODO make constant
+    .await
+    .expect("unable to get account data");
     // TODO: consider moving transaction hash to some constant.
     let tx = account_data.result.account_data.previous_transaction;
 

--- a/src/tests/conformance/stateful.rs
+++ b/src/tests/conformance/stateful.rs
@@ -4,7 +4,10 @@ use tempfile::TempDir;
 
 use crate::{
     setup::node::{Node, NodeType},
-    tools::rpc::{wait_for_account_data, wait_for_state},
+    tools::{
+        constants::EXPECTED_RESULT_TIMEOUT,
+        rpc::{wait_for_account_data, wait_for_state},
+    },
 };
 
 #[tokio::test]
@@ -18,9 +21,13 @@ async fn should_start_stop_stateful_node() {
         .expect("unable to start stateful node");
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
 
-    let account_data = wait_for_account_data(&node.rpc_url(), "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt")
-        .await
-        .expect("unable to get account data");
+    let account_data = wait_for_account_data(
+        &node.rpc_url(),
+        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
+        EXPECTED_RESULT_TIMEOUT,
+    )
+    .await
+    .expect("unable to get account data");
     assert_eq!(account_data.result.account_data.balance, "5000000000");
 
     node.stop().expect("unable to stop stateful node");

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -105,6 +105,15 @@ pub async fn get_ledger_info(rpc_url: &str) -> anyhow::Result<RpcResponse<Ledger
     execute_rpc(rpc_url, &request).await
 }
 
+pub async fn submit_transaction(
+    rpc_url: &str,
+    tx_blob: String,
+    fail_hard: bool,
+) -> anyhow::Result<RpcResponse<SubmitTransactionResponse>> {
+    let request = build_submit_transaction_request(tx_blob, fail_hard);
+    execute_rpc(rpc_url, &request).await
+}
+
 #[derive(Serialize)]
 struct LedgerInfoRequest {
     ledger_index: String,
@@ -124,6 +133,18 @@ fn build_transaction_info_request(transaction: String) -> RpcRequest<Vec<Transac
             transaction,
             binary: false,
         }],
+    }
+}
+
+fn build_submit_transaction_request(
+    tx_blob: String,
+    fail_hard: bool,
+) -> RpcRequest<Vec<SubmitTransactionRequest>> {
+    RpcRequest {
+        id: String::from("1"),
+        method: String::from("submit"),
+        api_version: API_VERSION,
+        params: vec![SubmitTransactionRequest { tx_blob, fail_hard }],
     }
 }
 
@@ -148,6 +169,20 @@ fn build_account_info_request(account: &str) -> RpcRequest<Vec<AccountInfoReques
             strict: false,
         }],
     }
+}
+
+#[derive(Serialize)]
+struct SubmitTransactionRequest {
+    tx_blob: String,
+    fail_hard: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(unused)]
+pub struct SubmitTransactionResponse {
+    accepted: bool,
+    applied: bool,
+    broadcast: bool,
 }
 
 #[derive(Serialize)]

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -178,11 +178,10 @@ struct SubmitTransactionRequest {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(unused)]
 pub struct SubmitTransactionResponse {
-    accepted: bool,
-    applied: bool,
-    broadcast: bool,
+    pub accepted: bool,
+    pub applied: bool,
+    pub broadcast: bool,
 }
 
 #[derive(Serialize)]

--- a/src/tools/rpc.rs
+++ b/src/tools/rpc.rs
@@ -29,8 +29,9 @@ pub async fn wait_for_state(rpc_url: &str, state: String) {
 pub async fn wait_for_account_data(
     rpc_url: &str,
     account: &str,
+    timeout: Duration,
 ) -> Result<RpcResponse<AccountInfoResponse>, Elapsed> {
-    tokio::time::timeout(EXPECTED_RESULT_TIMEOUT, async move {
+    tokio::time::timeout(timeout, async move {
         loop {
             if let Ok(account_data) = get_account_info(rpc_url, account).await {
                 return account_data;


### PR DESCRIPTION
1. Add timeout to `wait_for_account_data` function.
2. Add `submit_transaction` RPC call.
3. Add `mtTRANSACTION` relay test.