### PR TITLE
Chore: Make accounts' hashes into constants

### DIFF
--- a/src/tests/conformance/cmd/transaction.rs
+++ b/src/tests/conformance/cmd/transaction.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     setup::{constants::TESTNET_READY_TIMEOUT, testnet::TestNet},
     tools::{
+        constants::GENESIS_ACCOUNT,
         rpc::{submit_transaction, wait_for_account_data},
         synth_node::SyntheticNode,
     },
@@ -23,7 +24,7 @@ async fn c019_MT_TRANSACTION_node_should_broadcast_transaction_to_all_peers() {
     testnet.start().await.unwrap();
     wait_for_account_data(
         &testnet.running[NODE_IDS[0]].rpc_url(),
-        "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        GENESIS_ACCOUNT,
         TESTNET_READY_TIMEOUT,
     )
     .await

--- a/src/tests/conformance/query/get_by_hash.rs
+++ b/src/tests/conformance/query/get_by_hash.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     setup::node::{Node, NodeType},
     tools::{
-        constants::EXPECTED_RESULT_TIMEOUT,
+        constants::{EXPECTED_RESULT_TIMEOUT, TEST_ACCOUNT},
         rpc::{get_transaction_info, wait_for_account_data, wait_for_state},
         synth_node::SyntheticNode,
     },
@@ -30,13 +30,10 @@ async fn c007_TM_GET_OBJECT_BY_HASH_get_transaction_by_hash() {
 
     // Wait for correct state and account data.
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
-    let account_data = wait_for_account_data(
-        &node.rpc_url(),
-        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
-        EXPECTED_RESULT_TIMEOUT,
-    ) // TODO make constant
-    .await
-    .expect("unable to get account data");
+    let account_data =
+        wait_for_account_data(&node.rpc_url(), TEST_ACCOUNT, EXPECTED_RESULT_TIMEOUT)
+            .await
+            .expect("unable to get account data");
 
     // Get transaction info by rpc to put in cache.
     let tx = account_data.result.account_data.previous_transaction;
@@ -99,13 +96,10 @@ async fn c008_TM_HAVE_TRANSACTIONS_query_for_transactions_after_have_transaction
     // Wait for correct state and account data.
     // TODO Add enum to represent node's states.
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
-    let account_data = wait_for_account_data(
-        &node.rpc_url(),
-        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
-        EXPECTED_RESULT_TIMEOUT,
-    ) // TODO make constant
-    .await
-    .expect("unable to get account data");
+    let account_data =
+        wait_for_account_data(&node.rpc_url(), TEST_ACCOUNT, EXPECTED_RESULT_TIMEOUT)
+            .await
+            .expect("unable to get account data");
     // TODO: consider moving transaction hash to some constant.
     let tx = account_data.result.account_data.previous_transaction;
 

--- a/src/tests/conformance/stateful.rs
+++ b/src/tests/conformance/stateful.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 use crate::{
     setup::node::{Node, NodeType},
     tools::{
-        constants::EXPECTED_RESULT_TIMEOUT,
+        constants::{EXPECTED_RESULT_TIMEOUT, TEST_ACCOUNT},
         rpc::{wait_for_account_data, wait_for_state},
     },
 };
@@ -21,13 +21,10 @@ async fn should_start_stop_stateful_node() {
         .expect("unable to start stateful node");
     wait_for_state(&node.rpc_url(), "proposing".into()).await;
 
-    let account_data = wait_for_account_data(
-        &node.rpc_url(),
-        "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt",
-        EXPECTED_RESULT_TIMEOUT,
-    )
-    .await
-    .expect("unable to get account data");
+    let account_data =
+        wait_for_account_data(&node.rpc_url(), TEST_ACCOUNT, EXPECTED_RESULT_TIMEOUT)
+            .await
+            .expect("unable to get account data");
     assert_eq!(account_data.result.account_data.balance, "5000000000");
 
     node.stop().expect("unable to stop stateful node");

--- a/src/tools/constants.rs
+++ b/src/tools/constants.rs
@@ -5,3 +5,9 @@ pub const EXPECTED_RESULT_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Channel buffer bound for [InnerNode](crate::tools::inner_node::InnerNode) -> [SyntheticNode](crate::tools::synth_node::SyntheticNode) messages.
 pub const SYNTH_NODE_QUEUE_DEPTH: usize = 100;
+
+/// Ripple's genesis account. This is an account that holds all XRP when rippled starts from scratch.
+pub const GENESIS_ACCOUNT: &str = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
+
+/// A random but valid account that will be created in tests/setup by sending XRP from the GENESIS_ACCOUNT.
+pub const TEST_ACCOUNT: &str = "rNGknFCRBZguXcPqC63k6xTZnonSe6ZuWt";


### PR DESCRIPTION
This commit makes constants for two accounts' hashes that are often used in tests.
