### PR TITLE
Feature: test for User-agent header being too long

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -303,3 +303,12 @@ The test index makes use of symbolic language in describing connection and messa
     <>
     -> mtPROOF_PATH_REQ
     <- mtPROOF_PATH_RESPONSE
+
+## Resistance
+
+### ZG-RESISTANCE-001
+
+    The node rejects a handshake when the 'User-Agent' header is too long (8192 bytes in this test).
+    The node should be able to accept connections after such a request.
+    This test attempts a handshake with a long 'User-Agent' header and ensures that the connection
+    is rejected. Then, it attempts a normal connection and ensures that the connection is established.

--- a/src/protocol/handshake.rs
+++ b/src/protocol/handshake.rs
@@ -106,7 +106,8 @@ impl Handshake for InnerNode {
                 // prepare the HTTP request message
                 let mut request = Vec::new();
                 request.extend_from_slice(b"GET / HTTP/1.1\r\n");
-                request.extend_from_slice(b"User-Agent: rippled-1.9.1\r\n");
+                request
+                    .extend_from_slice(format!("User-Agent: {}\r\n", self.user_agent).as_bytes());
                 request.extend_from_slice(b"Connection: Upgrade\r\n");
                 request.extend_from_slice(b"Upgrade: XRPL/2.0, XRPL/2.1, XRPL/2.2\r\n"); // TODO: which ones should we handle?
                 request.extend_from_slice(b"Connect-As: Peer\r\n");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod conformance;
+mod resistance;

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -1,0 +1,40 @@
+use tempfile::TempDir;
+
+use crate::{
+    setup::node::{Node, NodeType},
+    tools::{config::TestConfig, synth_node::SyntheticNode},
+};
+
+#[allow(non_snake_case)]
+#[tokio::test]
+async fn r001_HANDSHAKE_reject_if_user_agent_too_long() {
+    // ZG-RESISTANCE-001
+
+    // Build and start the Ripple node.
+    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .start(target.path(), NodeType::Stateless)
+        .await
+        .expect("unable to start the node");
+
+    // Start the first synthetic node with a 'User-Agent' header that's too long.
+    let mut test_config = TestConfig::default();
+    test_config.synth_node_config.user_agent = format!("{:8192}", 0);
+    let synth_node1 = SyntheticNode::new(&test_config).await;
+    // Ensure this connection was rejected by the node.
+    assert!(synth_node1.connect(node.addr()).await.is_err());
+    assert_eq!(synth_node1.num_connected(), 0);
+    assert!(!synth_node1.is_connected(node.addr()));
+
+    // Start the second synthetic node with the default 'User-Agent'.
+    let synth_node2 = SyntheticNode::new(&Default::default()).await;
+    synth_node2.connect(node.addr()).await.unwrap();
+    // Ensure this connection was successful.
+    assert_eq!(synth_node2.num_connected(), 1);
+    assert!(synth_node2.is_connected(node.addr()));
+
+    // Shutdown all nodes.
+    synth_node1.shut_down().await;
+    synth_node2.shut_down().await;
+    node.stop().unwrap();
+}

--- a/src/tests/resistance/mod.rs
+++ b/src/tests/resistance/mod.rs
@@ -1,0 +1,1 @@
+mod handshake;

--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -42,6 +42,8 @@ pub struct SyntheticNodeTestConfig {
     pub initial_message: Option<Payload>,
     /// Whether or not to generate new keys for a handshake.
     pub generate_new_keys: bool,
+    /// 'User-Agent:' header to be set during a handshake.
+    pub user_agent: String,
 }
 
 impl Default for SyntheticNodeTestConfig {
@@ -50,6 +52,7 @@ impl Default for SyntheticNodeTestConfig {
             do_handshake: true,
             initial_message: None,
             generate_new_keys: true,
+            user_agent: "rippled-1.9.1".into(),
         }
     }
 }

--- a/src/tools/inner_node.rs
+++ b/src/tools/inner_node.rs
@@ -25,6 +25,7 @@ pub struct InnerNode {
     pub(crate) sender: Sender<(SocketAddr, BinaryMessage)>,
     pub crypto: Arc<Crypto>,
     pub tls: Tls,
+    pub user_agent: String,
 }
 
 // An object containing TLS handlers.
@@ -87,6 +88,7 @@ impl InnerNode {
                 acceptor,
                 connector,
             },
+            user_agent: config.synth_node_config.user_agent.clone(),
         }
     }
 

--- a/src/tools/synth_node.rs
+++ b/src/tools/synth_node.rs
@@ -33,7 +33,7 @@ pub fn enable_tracing() {
 }
 
 pub struct SyntheticNode {
-    pub inner: InnerNode,
+    inner: InnerNode,
     receiver: Receiver<(SocketAddr, BinaryMessage)>,
 }
 

--- a/src/tools/synth_node.rs
+++ b/src/tools/synth_node.rs
@@ -33,7 +33,7 @@ pub fn enable_tracing() {
 }
 
 pub struct SyntheticNode {
-    inner: InnerNode,
+    pub inner: InnerNode,
     receiver: Receiver<(SocketAddr, BinaryMessage)>,
 }
 


### PR DESCRIPTION
* Add option to set custom 'User-Agent' header for a handshake
* Add test for large User-Agent header used in a handshake