### PR TITLE
Feature: Test server identification too long

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -308,7 +308,8 @@ The test index makes use of symbolic language in describing connection and messa
 
 ### ZG-RESISTANCE-001
 
-    The node rejects a handshake when the 'User-Agent' header is too long (8192 bytes in this test).
+    The node rejects a handshake when the 'User-Agent' (for initiation side) or 'Server' (from responder side) header 
+    is too long (8192 bytes in this test).
     The node should be able to accept connections after such a request.
-    This test attempts a handshake with a long 'User-Agent' header and ensures that the connection
+    These tests attempt a handshake with long 'User-Agent'/'Server' headers and ensures that the connection
     is rejected. Then, it attempts a normal connection and ensures that the connection is established.

--- a/src/protocol/handshake.rs
+++ b/src/protocol/handshake.rs
@@ -106,8 +106,7 @@ impl Handshake for InnerNode {
                 // prepare the HTTP request message
                 let mut request = Vec::new();
                 request.extend_from_slice(b"GET / HTTP/1.1\r\n");
-                request
-                    .extend_from_slice(format!("User-Agent: {}\r\n", self.user_agent).as_bytes());
+                request.extend_from_slice(format!("User-Agent: {}\r\n", self.ident).as_bytes());
                 request.extend_from_slice(b"Connection: Upgrade\r\n");
                 request.extend_from_slice(b"Upgrade: XRPL/2.0, XRPL/2.1, XRPL/2.2\r\n"); // TODO: which ones should we handle?
                 request.extend_from_slice(b"Connect-As: Peer\r\n");
@@ -169,7 +168,7 @@ impl Handshake for InnerNode {
                 response.extend_from_slice(b"Connection: Upgrade\r\n");
                 response.extend_from_slice(b"Upgrade: XRPL/2.2\r\n");
                 response.extend_from_slice(b"Connect-As: Peer\r\n");
-                response.extend_from_slice(b"Server: rippled-1.9.1\r\n");
+                response.extend_from_slice(format!("Server: {}\r\n", self.ident).as_bytes());
                 response.extend_from_slice(format!("Public-Key: {}\r\n", base58_pk).as_bytes());
                 response.extend_from_slice(format!("Session-Signature: {}\r\n", sig).as_bytes());
                 response.extend_from_slice(b"X-Protocol-Ctl: txrr=1\r\n");

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -1,13 +1,17 @@
 use tempfile::TempDir;
+use tokio::time::sleep;
 
 use crate::{
-    setup::node::{Node, NodeType},
+    setup::{
+        constants::CONNECTION_TIMEOUT,
+        node::{Node, NodeType},
+    },
     tools::{config::TestConfig, synth_node::SyntheticNode},
 };
 
 #[allow(non_snake_case)]
 #[tokio::test]
-async fn r001_HANDSHAKE_reject_if_user_agent_too_long() {
+async fn r001_t1_HANDSHAKE_reject_if_user_agent_too_long() {
     // ZG-RESISTANCE-001
 
     // Build and start the Ripple node.
@@ -32,6 +36,45 @@ async fn r001_HANDSHAKE_reject_if_user_agent_too_long() {
     // Ensure this connection was successful.
     assert_eq!(synth_node2.num_connected(), 1);
     assert!(synth_node2.is_connected(node.addr()));
+
+    // Shutdown all nodes.
+    synth_node1.shut_down().await;
+    synth_node2.shut_down().await;
+    node.stop().unwrap();
+}
+
+#[allow(non_snake_case)]
+#[tokio::test]
+async fn r001_t2_HANDSHAKE_reject_if_server_too_long() {
+    // ZG-RESISTANCE-001
+
+    // Start the first synthetic node. Set identification ('Server' header) for the value that's too long.
+    let mut test_config = TestConfig::default();
+    test_config.synth_node_config.ident = format!("{:8192}", 0);
+    let synth_node1 = SyntheticNode::new(&test_config).await;
+
+    // Start the second synthetic node with the default 'Server' header.
+    let synth_node2 = SyntheticNode::new(&Default::default()).await;
+
+    // Build and start the Ripple node. Configure its peers such that it connects to the synthetic node above.
+    let target = TempDir::new().expect("Couldn't create a temporary directory");
+    let mut node = Node::builder()
+        .initial_peers(vec![
+            synth_node1.listening_addr().unwrap(),
+            synth_node2.listening_addr().unwrap(),
+        ])
+        .start(target.path(), NodeType::Stateless)
+        .await
+        .expect("unable to start the node");
+
+    // Wait for as long as is usually needed.
+    sleep(CONNECTION_TIMEOUT).await;
+
+    // Ensure the connection to the first synthetic node was rejected by the node.
+    assert!(!synth_node1.is_connected_ip(node.addr().ip()));
+
+    // Ensure the connection to the second synthetic node was successful.
+    assert!(synth_node2.is_connected_ip(node.addr().ip()));
 
     // Shutdown all nodes.
     synth_node1.shut_down().await;

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -19,7 +19,7 @@ async fn r001_HANDSHAKE_reject_if_user_agent_too_long() {
 
     // Start the first synthetic node with a 'User-Agent' header that's too long.
     let mut test_config = TestConfig::default();
-    test_config.synth_node_config.user_agent = format!("{:8192}", 0);
+    test_config.synth_node_config.ident = format!("{:8192}", 0);
     let synth_node1 = SyntheticNode::new(&test_config).await;
     // Ensure this connection was rejected by the node.
     assert!(synth_node1.connect(node.addr()).await.is_err());

--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -42,8 +42,8 @@ pub struct SyntheticNodeTestConfig {
     pub initial_message: Option<Payload>,
     /// Whether or not to generate new keys for a handshake.
     pub generate_new_keys: bool,
-    /// 'User-Agent:' header to be set during a handshake.
-    pub user_agent: String,
+    /// Identification header to be set during a handshake. Either 'User-Agent' or 'Server' depending on connection side.
+    pub ident: String,
 }
 
 impl Default for SyntheticNodeTestConfig {
@@ -52,7 +52,7 @@ impl Default for SyntheticNodeTestConfig {
             do_handshake: true,
             initial_message: None,
             generate_new_keys: true,
-            user_agent: "rippled-1.9.1".into(),
+            ident: "rippled-1.9.1".into(),
         }
     }
 }

--- a/src/tools/inner_node.rs
+++ b/src/tools/inner_node.rs
@@ -25,7 +25,7 @@ pub struct InnerNode {
     pub(crate) sender: Sender<(SocketAddr, BinaryMessage)>,
     pub crypto: Arc<Crypto>,
     pub tls: Tls,
-    pub user_agent: String,
+    pub ident: String,
 }
 
 // An object containing TLS handlers.
@@ -88,7 +88,7 @@ impl InnerNode {
                 acceptor,
                 connector,
             },
-            user_agent: config.synth_node_config.user_agent.clone(),
+            ident: config.synth_node_config.ident.clone(),
         }
     }
 


### PR DESCRIPTION
* Chore: Rename `user_agent` config field to `ident`
* Feature: Add test for large 'Server' header during handshake.