### PR TITLE
test: c026 for TmValidatorList, part 2

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -313,7 +313,6 @@ The test index makes use of symbolic language in describing connection and messa
 
     Assert: sequence number in the validator list and public key in the validator match what was sent.
 
-
 ## Performance
 
 ### ZG-PERFORMANCE-001

--- a/SPEC.md
+++ b/SPEC.md
@@ -306,8 +306,7 @@ The test index makes use of symbolic language in describing connection and messa
 
 ### ZG-CONFORMANCE-026
 
-    The test client should send a valid mtVALIDATORLIST message, with both master and signature public keys, correctly serializing a manifest and validator blob.
-    The create is done, but the result is not yet checked.  That will be done in a future task/PR.
+    The test client should send a valid mtVALIDATORLIST message, with both master and signature public keys, correctly serializing a manifest and validator blob.  A second node verifies the correctness by receiving the validator list in an mtVALIDATORLISTCOLLECTION message and verifying the contents.
 
     <>
     <- mtVALIDATORLIST sent with master and signing public keys and a correctly serialized manifest and validator blob.

--- a/SPEC.md
+++ b/SPEC.md
@@ -306,10 +306,13 @@ The test index makes use of symbolic language in describing connection and messa
 
 ### ZG-CONFORMANCE-026
 
-    The test client should send a valid mtVALIDATORLIST message, with both master and signature public keys, correctly serializing a manifest and validator blob.  A second node verifies the correctness by receiving the validator list in an mtVALIDATORLISTCOLLECTION message and verifying the contents.
+    A synthetic node sends a mtVALIDATORLIST message with both master and signature public keys, correctly serializing a manifest and validator blob to the node. To verify the node has received the message, another synthetic node awaits a mtVALIDATORLISTCOLLECTION message from the node with the same validator blob sent by the first synthetic node in its mtVALIDATORLIST message.
 
     <>
-    <- mtVALIDATORLIST sent with master and signing public keys and a correctly serialized manifest and validator blob.
+    -> mtVALIDATORLIST with master and signing public keys and a correctly serialized manifest and validator blob.
+
+    Assert: sequence number in the validator list and public key in the validator match what was sent.
+
 
 ## Performance
 

--- a/src/tests/conformance/post_handshake/validators.rs
+++ b/src/tests/conformance/post_handshake/validators.rs
@@ -264,7 +264,7 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
         let elapsed = start.elapsed();
         let millis = elapsed.as_millis();
         if millis > TIMEOUT_MILLIS {
-            assert!(false);
+            panic!("We have timed out, failing to receive valid TmValidatorListCollection message");
         }
         if let Payload::TmValidatorListCollection(validator_list_collection) = &m.payload {
             if let Some(blob_info) = validator_list_collection.blobs.first() {

--- a/src/tests/conformance/post_handshake/validators.rs
+++ b/src/tests/conformance/post_handshake/validators.rs
@@ -19,7 +19,7 @@ const ONE_YEAR: u32 = 86400 * 365;
 const JAN1_2000: u32 = 946684800;
 const RAND_SEQUENCE_NUMBER: u32 = 2022102584;
 const MANIFEST_PREFIX: &[u8] = b"MAN\x00";
-const TIMEOUT_MILLIS: Duration = Duration::from_secs(7);
+const WAIT_MSG_TIMEOUT: Duration = Duration::from_secs(5);
 
 // The master public key should be in the validators.txt file, in ~/.ziggurat/ripple/setup
 const MASTER_SECRET: &str = "8484781AE8EEB87D8A5AA38483B5CBBCCE6AD66B4185BB193DDDFAD5C1F4FC06";
@@ -274,10 +274,11 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
 
                 // Only our message has a single validator, so we skip the others
                 if validator_list.validators.len() == 1 {
-                    assert!(validator_list.sequence == RAND_SEQUENCE_NUMBER);
-                    assert!(validator_list.validators[0]
-                        .validation_public_key
-                        .eq(MASTER_PUBLIC));
+                    assert_eq!(validator_list.sequence, RAND_SEQUENCE_NUMBER);
+                    assert_eq!(
+                        validator_list.validators[0].validation_public_key,
+                        MASTER_PUBLIC
+                    );
                     return true;
                 }
             }
@@ -285,7 +286,7 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
         false
     };
 
-    timeout(TIMEOUT_MILLIS, async {
+    timeout(WAIT_MSG_TIMEOUT, async {
         while !synth_node2.expect_message(&check).await {
             continue;
         }

--- a/src/tests/conformance/post_handshake/validators.rs
+++ b/src/tests/conformance/post_handshake/validators.rs
@@ -1,11 +1,10 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::{BufMut, BytesMut};
 use secp256k1::{constants::PUBLIC_KEY_SIZE, Message, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 use tempfile::TempDir;
-use tokio::time::sleep;
 
 // serialization type field constants from rippled
 const ST_TAG_SEQUENCE: u8 = 0x24;
@@ -17,8 +16,9 @@ const ST_TAG_MASTER_SIGNATURE: u8 = 0x12;
 
 const ONE_YEAR: u32 = 86400 * 365;
 const JAN1_2000: u32 = 946684800;
-const RAND_SEQUENCE_NUMBER: u32 = 2022100501;
+const RAND_SEQUENCE_NUMBER: u32 = 2022102584;
 const MANIFEST_PREFIX: &[u8] = b"MAN\x00";
+const TIMEOUT_MILLIS: u128 = 5000;
 
 // The master public key should be in the validators.txt file, in ~/.ziggurat/ripple/setup
 const MASTER_SECRET: &str = "8484781AE8EEB87D8A5AA38483B5CBBCCE6AD66B4185BB193DDDFAD5C1F4FC06";
@@ -33,13 +33,8 @@ use crate::{
     },
     setup::node::{Node, NodeType},
     tests::conformance::{perform_expected_message_test, PUBLIC_KEY_TYPES},
-    tools::{config::TestConfig, synth_node::SyntheticNode},
+    tools::synth_node::SyntheticNode,
 };
-
-#[derive(Deserialize, Serialize)]
-struct ValidatorList {
-    validators: Vec<Validator>,
-}
 
 #[derive(Deserialize, Serialize)]
 struct Validator {
@@ -48,7 +43,7 @@ struct Validator {
 }
 
 #[derive(Deserialize, Serialize)]
-struct ValidatorBlob {
+struct ValidatorList {
     sequence: u32,
     expiration: u32,
     validators: Vec<Validator>,
@@ -118,18 +113,18 @@ fn get_expiration() -> u32 {
     now + year - JAN1_2000
 }
 
-fn create_validator_blob_json(manifest: &[u8], public_key: &str) -> String {
+fn create_validator_list_json(manifest: &[u8], public_key: &str) -> String {
     let validator = Validator {
         validation_public_key: public_key.to_string(),
         manifest: base64::encode(manifest),
     };
 
-    let vblob = ValidatorBlob {
+    let validator_list = ValidatorList {
         sequence: RAND_SEQUENCE_NUMBER,
         expiration: get_expiration(),
         validators: vec![validator],
     };
-    serde_json::to_string(&vblob).unwrap()
+    serde_json::to_string(&validator_list).unwrap()
 }
 
 fn create_manifest(sequence: u32, public_key: &[u8], signing_pub_key: &[u8]) -> BytesMut {
@@ -189,17 +184,20 @@ fn sign_buffer_with_prefix(hash_prefix: &[u8], secret_key: &SecretKey, buffer: &
 async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
     // Create stateful node.
     let target = TempDir::new().expect("unable to create TempDir");
-    let mut node = Node::builder()
+    let node = Node::builder()
         .log_to_stdout(true)
         .start(target.path(), NodeType::Stateless)
         .await
         .expect("unable to start stateful node");
 
-    let mut test_config = TestConfig::default();
-    test_config.synth_node_config.generate_new_keys = false;
-    let synth_node = SyntheticNode::new(&test_config).await;
-
-    synth_node
+    // create & connect two synth nodes
+    let synth_node1 = SyntheticNode::new(&Default::default()).await;
+    synth_node1
+        .connect(node.addr())
+        .await
+        .expect("unable to connect");
+    let mut synth_node2 = SyntheticNode::new(&Default::default()).await;
+    synth_node2
         .connect(node.addr())
         .await
         .expect("unable to connect");
@@ -241,7 +239,7 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
     let signed_manifest = sign_manifest(manifest, &master_signature_bytes, &signature_bytes);
 
     // 6. Create Validator blob.
-    let blob = create_validator_blob_json(&signed_manifest, MASTER_PUBLIC);
+    let blob = create_validator_list_json(&signed_manifest, MASTER_PUBLIC);
 
     // 7.  Get signature for blob using master private key
     let signature = sign_buffer(&signing_secret_key, blob.as_bytes());
@@ -257,14 +255,39 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
         signature,
         version: 1,
     });
-    synth_node
+    synth_node1
         .unicast(node.addr(), payload)
         .expect("unable to send message");
 
-    // TODO: confirm result from rippled that the message was valid
-    // will be done in new PR
+    let start = Instant::now();
+    let check = |m: &BinaryMessage| {
+        let elapsed = start.elapsed();
+        let millis = elapsed.as_millis();
+        if millis > TIMEOUT_MILLIS {
+            assert!(false);
+        }
+        if let Payload::TmValidatorListCollection(validator_list_collection) = &m.payload {
+            if let Some(blob_info) = validator_list_collection.blobs.first() {
+                let decoded_blob =
+                    base64::decode(&blob_info.blob).expect("unable to decode a blob");
 
-    sleep(Duration::from_secs(5)).await;
-    synth_node.shut_down().await;
-    node.stop().expect("unable to stop stateful node");
+                let text = String::from_utf8(decoded_blob)
+                    .expect("unable to convert decoded blob bytes to a string");
+
+                let validator_list = serde_json::from_str::<ValidatorList>(&text)
+                    .expect("unable to deserialize a validator list");
+
+                // Only our message has a single validator, so we skip the others
+                if validator_list.validators.len() == 1 {
+                    assert!(validator_list.sequence == RAND_SEQUENCE_NUMBER);
+                    assert!(validator_list.validators[0]
+                        .validation_public_key
+                        .eq(MASTER_PUBLIC));
+                    return true;
+                }
+            }
+        }
+        false
+    };
+    assert!(synth_node2.expect_message(&check).await);
 }

--- a/src/tests/conformance/post_handshake/validators.rs
+++ b/src/tests/conformance/post_handshake/validators.rs
@@ -288,7 +288,7 @@ async fn c026_TM_VALIDATOR_LIST_send_validator_list() {
     timeout(TIMEOUT_MILLIS, async {
         while !synth_node2.expect_message(&check).await {
             continue;
-         }
+        }
     })
     .await
     .expect("valid TmValidatorListCollection not received in time");


### PR DESCRIPTION
This PR covers the second part of the c026.  It performs the actual verification that a correctly-formed `TmValidatorList` message was received by `rippled`.
- creates two synth nodes
- sends our TmValidatorList message from node 1, and then node 2 listens for incoming TmValidatorListCollection messages
- filters the messages, looking for one with a single validator (the other two received have about 12 each).
- when it finds our message, does asserts on the random sequence value and master public key.  
- If no valid message is found after 5 seconds -- e.g., if I didn't send the original list message, or if I sent an invalid message -- then the test would fail.  This test only confirms a positive result.
