### PR TITLE
refactor: ping performance test can use different source IPs

### DIFF
--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -2,7 +2,6 @@ use std::{
     io::ErrorKind,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
-    thread,
     time::{Duration, Instant},
 };
 
@@ -26,6 +25,7 @@ use crate::{
     },
 };
 
+const MAX_PEERS: usize = 100;
 const PINGS: u16 = 1000;
 const METRIC_LATENCY: &str = "ping_perf_latency";
 const CONNECTION_PORT: u16 = 31337;
@@ -44,11 +44,9 @@ async fn p001_t1_PING_PONG_throughput() {
     //       of the results table. This is because the results will rely on the machine
     //       running the test.
     //
-    // rippled: Currently seems to perform a bit below the expectations. Default config for rippled sets max_peers
-    //          to 0 which means no limit. As stated in src/ripple/peerfinder/impl/Tuning.h defaultMaxPeers = 21 so
-    //          rippled should response fine at least to 21 peers.
-    //          As it was in zcash, tests can produce different error messages during run to indicate what is
-    //          going on with the current connection.
+    // rippled: Currently seems to perform quite well. There is one important condition - connections
+    //          must be established with different source IPs. When connections come from single IP
+    //          the performance drops significantly.
     //          There are possible several error messages during the test:
     //          `Result::unwrap()` on an `Err` value: Kind(InvalidData) - when connect to node failed
     //          `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }' - communication with
@@ -59,41 +57,27 @@ async fn p001_t1_PING_PONG_throughput() {
     //          connections cannot be established and other ones are closed during the test. However, amount of nodes and ping count
     //          does not affect the latency and rippled responses have similar std time.
     //
-    // Example test result (with percentile latencies) - 50 pings per node:
+    // Example test result (with percentile latencies) - 1000 pings per node with max_peers set to 100:
     // ┌─────────┬────────────┬────────────┬────────────┬────────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────────┬────────────┬──────────────┐
     // │  peers  │  requests  │  min (ms)  │  max (ms)  │  std dev (ms)  │  10% (ms)  │  50% (ms)  │  75% (ms)  │  90% (ms)  │  99% (ms)  │  completion %  │  time (s)  │  requests/s  │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │       1 │         50 │          0 │         40 │              6 │          0 │          0 │          0 │          0 │         40 │         100.00 │       0.17 │       298.37 │
+    // │       1 │       1000 │          0 │         49 │              3 │          0 │          0 │          0 │          0 │          0 │         100.00 │       0.59 │      1698.56 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      10 │         50 │          0 │         49 │              6 │          0 │          0 │          0 │          0 │         46 │         100.00 │       2.10 │       237.73 │
+    // │      10 │       1000 │          0 │         58 │              2 │          0 │          0 │          0 │          0 │          0 │         100.00 │       2.02 │      4961.28 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      15 │         50 │          0 │         49 │              6 │          0 │          0 │          0 │          0 │         45 │         100.00 │       2.93 │       256.17 │
+    // │      15 │       1000 │          0 │         59 │              6 │          0 │          0 │          0 │          0 │         43 │         100.00 │       2.82 │      5328.07 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      20 │         50 │          0 │         49 │              4 │          0 │          0 │          0 │          0 │          9 │          79.80 │      13.82 │        57.74 │
+    // │      20 │       1000 │          0 │         60 │              4 │          0 │          0 │          0 │          0 │          0 │         100.00 │       4.22 │      4743.56 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      30 │         50 │          0 │        302 │             14 │          0 │          0 │          0 │          0 │         47 │          45.67 │      15.82 │        43.30 │
+    // │      30 │       1000 │          0 │         59 │              7 │          0 │          0 │          0 │          0 │         49 │         100.00 │       6.94 │      4319.85 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      50 │         50 │          0 │         54 │              7 │          0 │          0 │          0 │          0 │         43 │          33.48 │      20.24 │        41.35 │
-    // └─────────┴────────────┴────────────┴────────────┴────────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────────┴────────────┴──────────────┘
-    //
-    // Example test result (with percentile latencies) - 150 pings per node:
-    // ┌─────────┬────────────┬────────────┬────────────┬────────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────────┬────────────┬──────────────┐
-    // │  peers  │  requests  │  min (ms)  │  max (ms)  │  std dev (ms)  │  10% (ms)  │  50% (ms)  │  75% (ms)  │  90% (ms)  │  99% (ms)  │  completion %  │  time (s)  │  requests/s  │
+    // │      50 │       1000 │          0 │        369 │              8 │          0 │          0 │          0 │          0 │         47 │         100.00 │      11.20 │      4463.01 │
     // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │       1 │        150 │          0 │         47 │              4 │          0 │          0 │          0 │          0 │         47 │         100.00 │       0.32 │       464.77 │
-    // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      10 │        150 │          0 │         58 │              4 │          0 │          0 │          0 │          0 │          0 │         100.00 │       2.26 │       664.91 │
-    // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      15 │        150 │          0 │         49 │              8 │          0 │          0 │          0 │          0 │         49 │          14.84 │      12.08 │        27.64 │
-    // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      20 │        150 │          0 │         41 │              5 │          0 │          0 │          0 │          0 │         41 │          16.13 │      13.04 │        37.12 │
-    // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      30 │        150 │          0 │         23 │              2 │          0 │          0 │          0 │          0 │         11 │          13.24 │      15.40 │        38.70 │
-    // ├─────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────────┼────────────┼──────────────┤
-    // │      50 │        150 │          0 │         36 │              2 │          0 │          0 │          0 │          0 │          1 │           9.59 │      18.67 │        38.52 │
+    // │     100 │       1000 │          0 │       3130 │             48 │          0 │          0 │          0 │          1 │         44 │          71.01 │     137.67 │       515.81 │
     // └─────────┴────────────┴────────────┴────────────┴────────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────────┴────────────┴──────────────┘
     //
     // *NOTE* run with `cargo test --release tests::performance::ping_pong -- --nocapture`
+    // Before running test generate dummy devices with different ips using toos/ips.py
 
     let synth_counts = vec![1, 10, 15, 20, 30, 50, 100];
 
@@ -101,7 +85,7 @@ async fn p001_t1_PING_PONG_throughput() {
 
     let target = TempDir::new().expect("Unable to create TempDir");
     let mut node = Node::builder()
-        .max_peers(100)
+        .max_peers(MAX_PEERS)
         .start(target.path(), NodeType::Stateless)
         .await
         .unwrap();
@@ -167,7 +151,6 @@ async fn simulate_peer(node_addr: SocketAddr, thread_num: usize) {
             IpAddr::V4(Ipv4Addr::from_str(IPS[thread_num]).unwrap()),
             CONNECTION_PORT,
         );
-        println!("Setting source address to {}", source_addr);
         config.pea2pea_config.bound_addr = Some(source_addr);
     }
 

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -97,7 +97,7 @@ async fn p001_t1_PING_PONG_throughput() {
     // If the table is empty or too small, the thread itself will notice it and will use the
     // local IP.
     // It can be removed once pea2pea will offer REUSE_ADDR options.
-    let mut used = 0;
+    let mut ip_idx = 0;
 
     for synth_count in synth_counts {
         // setup metrics recorder
@@ -107,11 +107,10 @@ async fn p001_t1_PING_PONG_throughput() {
 
         let mut synth_handles = Vec::with_capacity(synth_count);
         let test_start = tokio::time::Instant::now();
-        for i in 0..synth_count {
-            synth_handles.push(tokio::spawn(simulate_peer(node_addr, i + used)));
+        for _ in 0..synth_count {
+            synth_handles.push(tokio::spawn(simulate_peer(node_addr, ip_idx)));
+            ip_idx += 1;
         }
-
-        used += synth_count;
 
         // wait for peers to complete
         for handle in synth_handles {

--- a/src/tools/ips.rs
+++ b/src/tools/ips.rs
@@ -5,5 +5,4 @@
 /// Reference to a static array of IP addresses (represented as str).
 /// If array is empty generate new addresses using eg.:
 /// python3 tools/ips.py --subnet 1.1.1.0/28 --file src/tools/ips.rs --dev_prefix test_dev
-pub const IPS: &'static [&'static str] = &[
-];
+pub const IPS: &[&str] = &[];

--- a/src/tools/ips.rs
+++ b/src/tools/ips.rs
@@ -1,0 +1,9 @@
+// If the IPS array is empty then it means that source IP addresses have not been
+// generated and assigned to dummy devices. In such case tests should not bound to any
+// specific address and use local pool instead.
+
+/// Reference to a static array of IP addresses (represented as str).
+/// If array is empty generate new addresses using eg.:
+/// python3 tools/ips.py --subnet 1.1.1.0/28 --file src/tools/ips.rs --dev_prefix test_dev
+pub const IPS: &'static [&'static str] = &[
+];

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod constants;
 pub mod inner_node;
+pub mod ips;
 pub mod metrics;
 pub mod rpc;
 pub mod synth_node;


### PR DESCRIPTION
This PR gives ability for performance ping test to use different IP addresses.

Currently it's recommended to generate addresses to cover all iterations of all tests, so it would be good to generate whole 24bit subnet. When pea2pea will allow to set REUSE_ADDR option "the hack" can be removed. 