### PR TITLE
feat: add presenting basic crawler stats

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -13,6 +13,7 @@ use crate::{
     args::Args,
     crawler::Crawler,
     metrics::NetworkSummary,
+    network::update_summary_snapshot_task,
     rpc::{initialize_rpc_server, RpcContext},
 };
 
@@ -64,7 +65,10 @@ async fn main() {
         .timeout(CRAWLER_TIMEOUT)
         .build()
         .expect("unable to build the web client");
-
+    tokio::spawn(update_summary_snapshot_task(
+        crawler.known_network.clone(),
+        summary_snapshot,
+    ));
     for addr in args.seed_addrs {
         crawler::crawl(client.clone(), addr, crawler.known_network.clone()).await;
     }

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -1,4 +1,30 @@
+use std::{collections::HashMap, sync::Arc};
+
 use serde::Serialize;
 
+use crate::network::KnownNetwork;
+
 #[derive(Default, Clone, Serialize)]
-pub(super) struct NetworkSummary {}
+pub(super) struct NetworkSummary {
+    num_known_nodes: usize,
+    num_good_nodes: usize,
+    num_known_connections: usize,
+}
+
+impl NetworkSummary {
+    /// Builds a new [NetworkSummary] out of current state of [KnownNetwork]
+    pub(super) async fn new(known_network: Arc<KnownNetwork>) -> Self {
+        let nodes = known_network.nodes().await;
+        let connections = known_network.connections().await;
+        let good_nodes: HashMap<_, _> = nodes
+            .clone()
+            .into_iter()
+            .filter(|(_, node)| node.last_connected.is_some())
+            .collect();
+        Self {
+            num_known_nodes: nodes.len(),
+            num_good_nodes: good_nodes.len(),
+            num_known_connections: connections.len(),
+        }
+    }
+}


### PR DESCRIPTION
Presents basic stats (number of nodes and connections) via rpc.