### PR TITLE
r001_t2 Mac fix: detect connection using num_connected function

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -165,7 +165,7 @@ impl RippledConfigFile {
 
         // 5. Reporting mode
 
-        // 6. Datababase
+        // 6. Database
 
         writeln!(&mut config_str, "[node_db]")?;
         writeln!(&mut config_str, "type=NuDB")?;

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -141,6 +141,10 @@ impl NodeBuilder {
             self.meta.start_args.push("--nodetoshard".into());
         }
 
+        if self.conf.log_to_stdout {
+            self.meta.start_args.push("--debug".into());
+        }
+
         self.meta.start_args.push("--conf".into());
         self.meta.start_args.push(rippled_cfg_path.into());
 

--- a/src/tests/resistance/handshake.rs
+++ b/src/tests/resistance/handshake.rs
@@ -82,16 +82,10 @@ async fn r001_t2_HANDSHAKE_reject_if_server_too_long() {
         .expect("unable to start the node");
 
     // Ensure the connection to the second synthetic node was successful.
-    wait_until!(
-        CONNECTION_TIMEOUT,
-        synth_node2.is_connected_ip(node.addr().ip())
-    );
+    wait_until!(CONNECTION_TIMEOUT, synth_node2.num_connected() > 0);
 
     // Ensure the connection to the first synthetic node was rejected by the node.
-    wait_until!(
-        CONNECTION_TIMEOUT,
-        !synth_node1.is_connected_ip(node.addr().ip())
-    );
+    wait_until!(CONNECTION_TIMEOUT, synth_node1.num_connected() == 0);
 
     // Shutdown all nodes.
     synth_node1.shut_down().await;


### PR DESCRIPTION
```
    fix: detect connection using num_connected function

    - when the node initiates the connection,
      we cannot assume correctly fwhich IP the node will
      use to create a network socket. Therefore, we shouldn't
      use `is_connected` function in this test
```
```
    chore: allow extra debug traces

    Enable extra debug traces from the node when the log_to_stdout option is
    used.
```