### PR TITLE
feat: update crawler to use latest NetworkSummary & spectre

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,12 +91,13 @@ default-features = false
 features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"]
 
 [dependencies.spectre]
-version = "0.5.1"
+git = "https://github.com/niklaslong/spectre"
+rev = "f1d6698"
 optional = true
 
 [dependencies.ziggurat-core-crawler]
 git = "https://github.com/runziggurat/ziggurat-core"
-rev = "2de7a9d"
+rev = "001c943"
 optional = true
 
 [features]

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -38,9 +38,9 @@ pub(super) async fn new_network_summary(
     let good_nodes = get_good_nodes(&nodes);
     let server_versions = get_server_versions(&nodes);
 
-    let agraph = metrics
+    let indices = metrics
         .graph
-        .create_agraph(&good_nodes.keys().copied().collect());
+        .get_filtered_adjacency_indices(&good_nodes.keys().copied().collect());
 
     NetworkSummary {
         num_known_nodes: nodes.len(),
@@ -49,7 +49,7 @@ pub(super) async fn new_network_summary(
         node_ips: good_nodes.iter().map(|n| n.0.to_string()).collect(),
         user_agents: server_versions,
         crawler_runtime,
-        agraph,
+        indices,
         ..Default::default()
     }
 }


### PR DESCRIPTION
Exactly the same as with zcash, I've updated the xrpl crawler to use:
• new spectre API to fetch indices
• remove AGraph as struct, using updated NetworkSummary
