### PR TITLE
feat(crawler): add Display trait

### DIFF
--- a/src/tools/crawler/crawl.rs
+++ b/src/tools/crawler/crawl.rs
@@ -1,6 +1,7 @@
 //! Contains structs and methods to crawl ripple network according to instruction at https://xrpl.org/peer-crawler.html
 
 use std::{
+    fmt,
     net::{IpAddr, SocketAddr},
     time::Duration,
 };
@@ -10,23 +11,62 @@ use serde::Deserialize;
 use thiserror::Error;
 use tokio::time::Instant;
 
-#[allow(dead_code)]
-#[derive(Debug, Deserialize)]
-pub(super) struct Peer {
-    pub(super) complete_ledgers: Option<String>,
-    pub(super) complete_shards: Option<String>,
-    pub(super) ip: Option<String>,
-    pub(super) port: Option<Port>,
-    pub(super) public_key: String,
+/// Each member of the overlay active array is an object with the following fields.
+#[derive(Debug, Deserialize, Clone)]
+pub struct Peer {
+    /// The range of ledger versions this peer has available.
+    pub complete_ledgers: Option<String>,
+
+    /// The range of ledger history shards this peer has available.
+    pub complete_shards: Option<String>,
+
+    /// The IP address of this connected peer.
+    ///
+    /// Omitted if the peer is configured as a validator or a private peer.
+    pub ip: Option<String>,
+
+    /// The port number on the peer server that serves RTXP.
+    ///
+    /// Typically 51235.
+    /// Omitted if the peer is configured as a validator or a private peer.
+    pub port: Option<Port>,
+
+    /// The public key of the ECDSA key pair used by this peer to sign RTXP messages.
+    pub public_key: String,
+
+    /// Indicating whether the TCP connection to the peer is incoming or outgoing.
+    ///
+    /// The value is "in" or "out".
     #[serde(rename = "type")]
-    pub(super) connection_type: String,
-    pub(super) uptime: u32,
-    pub(super) version: String,
+    pub connection_type: String,
+
+    /// The number of seconds the server has been connected to this peer.
+    #[serde(rename = "uptime")]
+    pub connection_uptime: u32,
+
+    /// The rippled version number the peer reports to be using.
+    pub version: String,
+}
+
+impl fmt::Display for Peer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ip = self.ip.clone().unwrap_or_default();
+        let port = self.port.clone().unwrap_or_default();
+        let public_key = &self.public_key;
+        let uptime = &self.connection_uptime;
+
+        writeln!(f, "[{uptime:05}]: {ip}:{port}\t\t\t{public_key}")?;
+        writeln!(
+            f,
+            "[{:3}]: \t\t\t\tversion: {:20} \t\tshards: {:?} ledgers: {:?}",
+            self.connection_type, self.version, self.complete_shards, self.complete_ledgers
+        )
+    }
 }
 
 impl Peer {
     /// Returns port number for the peer.
-    pub(super) fn port(&self) -> Option<u16> {
+    pub fn port(&self) -> Option<u16> {
         self.port.as_ref().and_then(|p| match p {
             Port::Number(n) => Some(*n),
             Port::String(s) => s.parse().ok(),
@@ -34,46 +74,107 @@ impl Peer {
     }
 }
 
-#[derive(Deserialize)]
-pub(super) struct CrawlResponse {
-    pub(super) overlay: Overlay,
-    pub(super) server: Server,
+#[derive(Debug, Deserialize)]
+pub struct CrawlResponse {
+    /// Information about the peer servers currently connected to this one,
+    /// similar to the response from the peers method.
+    #[serde(rename = "overlay")]
+    pub peerlist: Overlay,
+
+    /// Information about this server.
+    pub server: Server,
 }
 
-#[derive(Deserialize)]
-pub(super) struct Overlay {
-    pub(super) active: Vec<Peer>,
-}
-
-#[allow(dead_code)]
-#[derive(Deserialize)]
-pub(super) struct Server {
-    pub(super) build_version: String,
-    pub(super) server_state: String,
-    pub(super) uptime: u32,
+impl fmt::Display for CrawlResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, " server: {}", self.server)?;
+        writeln!(f, " peerlist:\n{}", self.peerlist)
+    }
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Overlay {
+    pub active: Vec<Peer>,
+}
+
+impl fmt::Display for Overlay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Sort the peers here by the IP address.
+        let mut peers = self.active.clone();
+        peers.sort_by(|a, b| {
+            let a_ip = a.ip.clone().unwrap_or_default();
+            let b_ip = b.ip.clone().unwrap_or_default();
+
+            a_ip.cmp(&b_ip)
+        });
+
+        for peer in peers {
+            writeln!(f, "{peer}")?;
+        }
+        writeln!(f)
+    }
+}
+
+/// Information about this server.
+#[derive(Debug, Deserialize)]
+pub struct Server {
+    /// The version number of the running rippled version.
+    pub build_version: String,
+
+    ///  A string indicating to what extent the server is participating in the network.
+    pub server_state: String,
+
+    /// Number of consecutive seconds that the server has been operational.
+    pub uptime: u32,
+}
+
+impl fmt::Display for Server {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "build_version: {}, ", self.build_version)?;
+        write!(f, "server_state: {}, ", self.server_state)?;
+        write!(f, "server_uptime: {}", self.uptime)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
-pub(super) enum Port {
+pub enum Port {
     Number(u16),
     String(String),
+}
+
+impl Default for Port {
+    fn default() -> Self {
+        Self::String("".to_owned())
+    }
+}
+
+impl fmt::Display for Port {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let port_str = match self {
+            Self::Number(num) => num.to_string(),
+            Self::String(string) => string.clone(),
+        };
+        write!(f, "{port_str}")
+    }
 }
 
 /// Connects to `https://IP:PORT/crawl` to query `addr's` peers.
 /// On success returns the response and the time it took to connect, send the request and read the response.
 /// On failure it returns a [CrawlError].
-pub(super) async fn get_crawl_response(
+pub async fn get_crawl_response(
     client: Client,
     addr: SocketAddr,
 ) -> Result<(CrawlResponse, Duration), CrawlError> {
     let url = format!("https://{}:{}/crawl", format_ip_for_url(addr), addr.port());
+
     let start = Instant::now();
     let response = client
         .get(url)
         .send()
         .await
         .map_err(|e| CrawlError::Connection(e.to_string()))?;
+
     let elapsed = start.elapsed();
     if response.status() == StatusCode::OK {
         let response = response
@@ -100,7 +201,7 @@ fn format_ip_for_url(addr: SocketAddr) -> String {
 }
 
 #[derive(Debug, Error)]
-pub(super) enum CrawlError {
+pub enum CrawlError {
     #[error("unable to connect: {0}")]
     Connection(String),
 
@@ -124,7 +225,7 @@ mod test {
             port: Some(Port::String("not valid".into())),
             public_key: "".to_string(),
             connection_type: "".to_string(),
-            uptime: 0,
+            connection_uptime: 0,
             version: "".to_string(),
         };
         assert!(peer.port().is_none());
@@ -139,7 +240,7 @@ mod test {
             port: Some(Port::String(PORT_STRING.into())),
             public_key: "".to_string(),
             connection_type: "".to_string(),
-            uptime: 0,
+            connection_uptime: 0,
             version: "".to_string(),
         };
         assert!(matches!(peer.port(), Some(PORT_NUMBER)));
@@ -154,7 +255,7 @@ mod test {
             port: Some(Port::Number(PORT_NUMBER)),
             public_key: "".to_string(),
             connection_type: "".to_string(),
-            uptime: 0,
+            connection_uptime: 0,
             version: "".to_string(),
         };
         assert!(matches!(peer.port(), Some(PORT_NUMBER)));

--- a/src/tools/crawler/crawler.rs
+++ b/src/tools/crawler/crawler.rs
@@ -141,7 +141,7 @@ async fn try_crawling(
 /// Extract addresses from /crawl response.
 async fn extract_known_nodes(response: &CrawlResponse) -> Vec<(IpAddr, Option<u16>)> {
     response
-        .overlay
+        .peerlist
         .active
         .iter()
         .filter_map(parse_peer_addr)


### PR DESCRIPTION
- formatted printout with compressed info so it doesn't clutter the output with many newlines
- removed `(super)` from `pub(super)` because the `crawl` mod will be taken out and used by other tests from this binary (source code tree)

example of the printout:
```
 server: build_version: 1.9.4, server_state: connected, server_uptime: 36
 peerlist:
[00034]: 100.24.12.73:51235                     AyT/MLgoFGxwXrV8t0WVxZFQw8LgV4ypYXn8rp5ewGzd
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")

[00034]: 13.48.204.149:51235                    ArO1nS71bRFvZPx3qWtev20+k3D5B4Aji9k68Wgprjyu
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")

[00034]: 13.49.231.59:51235                     AmRS+0qkiLq9fwm7y127MsHOWjMriljE3bdhFyMHxpIN
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")

[00034]: 18.232.83.47:51235                     A7t8t5IDUoV8r5jFNZ/u+ym9nWx+5mSMnRiYuxTBkV9f
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")

[00034]: 3.122.10.154:51235                     A/7PxSIKPdsfBuoI4u87SRup4yCK+Ric+ijvhyPmq8x7
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")

[00034]: 34.230.16.97:51235                     AmMC5HVYfRTFKKO+O+enrnm70GE0SknM8pXrcYnV2sKa
[out]:                          version: rippled-1.9.4                  shards: None ledgers: Some("77995485-78015485")
```