### PR TITLE
refactor(synth_node): more flexible handshake cfg

### DIFF
--- a/src/tests/conformance/cmd/cluster.rs
+++ b/src/tests/conformance/cmd/cluster.rs
@@ -11,7 +11,7 @@ use crate::{
         constants::{DEFAULT_PORT, SYNTHETIC_NODE_PUBLIC_KEY},
         node::{Node, NodeType},
     },
-    tools::{config::TestConfig, synth_node::SyntheticNode},
+    tools::{config::SynthNodeCfg, synth_node::SyntheticNode},
 };
 
 #[allow(non_snake_case)]
@@ -21,10 +21,11 @@ async fn c024_TM_CLUSTER_node_should_connect_to_other_nodes_in_cluster() {
 
     // Start a synthetic node configured to use known keys so that rippled knows who it's talking to.
     let synth_node_ip = "127.0.0.2".parse().unwrap();
-    let mut test_config = TestConfig::default();
+    let mut test_config = SynthNodeCfg::default();
     test_config.pea2pea_config.listener_ip = Some(IpAddr::V4(synth_node_ip));
     test_config.pea2pea_config.desired_listening_port = Some(DEFAULT_PORT);
-    test_config.synth_node_config.generate_new_keys = false;
+    test_config.generate_new_keys = false;
+
     let mut synth_node = SyntheticNode::new(&test_config).await;
     let listening_addr = synth_node
         .start_listening()

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -6,8 +6,8 @@ use crate::{
         constants::CONNECTION_TIMEOUT,
         node::{Node, NodeType},
     },
-    tests::conformance::perform_expected_message_test,
-    tools::{config::TestConfig, synth_node::SyntheticNode},
+    tests::conformance::{perform_expected_message_test, TestConfig},
+    tools::synth_node::SyntheticNode,
     wait_until,
 };
 
@@ -72,6 +72,7 @@ async fn c002_handshake_when_node_initiates_connection() {
 async fn c006_node_should_not_send_any_messages_if_no_handshake() {
     // ZG-CONFORMANCE-006
     let response_check = |_: &BinaryMessage| true;
-    perform_expected_message_test(TestConfig::default().with_handshake(false), &response_check)
+
+    perform_expected_message_test(TestConfig::default().with_handshake(None), &response_check)
         .await;
 }

--- a/src/tests/conformance/query/ledger.rs
+++ b/src/tests/conformance/query/ledger.rs
@@ -8,8 +8,7 @@ use crate::{
         codecs::message::{BinaryMessage, Payload},
         proto::{TmGetLedger, TmLedgerInfoType, TmLedgerType},
     },
-    tests::conformance::perform_expected_message_test,
-    tools::config::TestConfig,
+    tests::conformance::{perform_expected_message_test, TestConfig},
 };
 
 #[tokio::test]

--- a/src/tests/conformance/query/ping_pong.rs
+++ b/src/tests/conformance/query/ping_pong.rs
@@ -10,8 +10,7 @@ use crate::{
         codecs::message::{BinaryMessage, Payload},
         proto::{tm_ping::PingType, TmPing},
     },
-    tests::conformance::perform_expected_message_test,
-    tools::config::TestConfig,
+    tests::conformance::{perform_expected_message_test, TestConfig},
 };
 
 #[tokio::test]

--- a/src/tests/idle_node_in_the_background.rs
+++ b/src/tests/idle_node_in_the_background.rs
@@ -17,7 +17,7 @@ use ziggurat_core_utils::err_constants::{
 use crate::{
     setup::node::{Node, NodeType},
     tools::{
-        config::TestConfig,
+        config::SynthNodeCfg,
         crawl,
         synth_node::{self, SyntheticNode},
     },
@@ -51,8 +51,8 @@ enum TracingOpt {
 enum SynthNodeOpt {
     #[default]
     Off,
-    On_OnlyListening(TestConfig),
-    On_TryToConnect(TestConfig),
+    On_OnlyListening(SynthNodeCfg),
+    On_TryToConnect(SynthNodeCfg),
 }
 
 #[derive(Default)]
@@ -116,7 +116,7 @@ async fn dev002_t1_MONITOR_NODE_FOREVER_WITH_SYNTH_NODE_sn_is_conn_initiator() {
     let mut cfg = DevTestCfg::default();
     cfg.tracing = TracingOpt::On;
     cfg.crawl = PeriodicCrawlOpt::On(Duration::from_secs(5));
-    cfg.synth_node = SynthNodeOpt::On_TryToConnect(TestConfig::default());
+    cfg.synth_node = SynthNodeOpt::On_TryToConnect(SynthNodeCfg::default());
     node_run_forever(cfg).await;
 
     panic!("the node shouldn't have died");
@@ -132,7 +132,7 @@ async fn dev002_t2_MONITOR_NODE_FOREVER_WITH_SYNTH_NODE_sn_is_conn_responder() {
     cfg.log_to_stdout = NodeLogToStdout::On;
     cfg.tracing = TracingOpt::On;
     cfg.crawl = PeriodicCrawlOpt::On(Duration::from_secs(5));
-    cfg.synth_node = SynthNodeOpt::On_OnlyListening(TestConfig::default());
+    cfg.synth_node = SynthNodeOpt::On_OnlyListening(SynthNodeCfg::default());
     node_run_forever(cfg).await;
 
     panic!("the node shouldn't have died");

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -16,7 +16,7 @@ use ziggurat_core_utils::err_constants::{
 
 use crate::{
     setup::node::{Node, NodeType},
-    tools::{config::TestConfig, ips::IPS, synth_node::SyntheticNode},
+    tools::{config::SynthNodeCfg, ips::IPS, synth_node::SyntheticNode},
 };
 
 const METRIC_ACCEPTED: &str = "perf_conn_accepted";
@@ -250,7 +250,7 @@ async fn p002_connections_load() {
 }
 
 async fn simulate_peer(node_addr: SocketAddr, handshake_complete: Sender<()>, socket: TcpSocket) {
-    let config = TestConfig::default();
+    let config = SynthNodeCfg::default();
 
     let mut synth_node = SyntheticNode::new(&config).await;
 

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -23,7 +23,7 @@ use crate::{
         proto::{tm_ping::PingType, TmPing},
     },
     setup::node::{Node, NodeType},
-    tools::{config::TestConfig, ips::IPS, synth_node::SyntheticNode},
+    tools::{config::SynthNodeCfg, ips::IPS, synth_node::SyntheticNode},
 };
 
 const MAX_PEERS: usize = 100;
@@ -156,7 +156,7 @@ async fn p001_t1_PING_PONG_throughput() {
 
 #[allow(unused_must_use)] // just for result of the timeout
 async fn simulate_peer(node_addr: SocketAddr, socket: TcpSocket) {
-    let config = TestConfig::default();
+    let config = SynthNodeCfg::default();
 
     let mut synth_node = SyntheticNode::new(&config).await;
 

--- a/src/tests/resistance/random_bytes.rs
+++ b/src/tests/resistance/random_bytes.rs
@@ -5,7 +5,7 @@ use tempfile::TempDir;
 use crate::{
     fuzzing::{random_bytes, seeded_rng},
     setup::node::{Node, NodeType},
-    tools::{config::TestConfig, synth_node::SyntheticNode},
+    tools::{config::SynthNodeCfg, synth_node::SyntheticNode},
     wait_until,
 };
 
@@ -56,8 +56,11 @@ async fn r004_node_must_disconnect_when_receiving_random_bytes_pre_handshake() {
         .await
         .expect("unable to start the node");
 
-    let mut cfg: TestConfig = Default::default();
-    cfg.synth_node_config.do_handshake = false; // Disable handshake.
+    let cfg = SynthNodeCfg {
+        handshake: None, // Disable handshake.
+        ..Default::default()
+    };
+
     for payload in payloads {
         let synth_node = SyntheticNode::new(&cfg).await;
         synth_node.connect(node.addr()).await.unwrap();

--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -1,66 +1,32 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use crate::protocol::codecs::message::Payload;
-#[cfg(doc)]
-use crate::tools::synth_node::SyntheticNode;
+use crate::protocol::handshake::HandshakeCfg;
 
-/// Test configuration. Contains setup options for [SyntheticNode] and [pea2pea::Config].
+/// Synthetic Node Configuration.
 #[derive(Clone)]
-pub struct TestConfig {
-    pub synth_node_config: SyntheticNodeTestConfig,
+pub struct SynthNodeCfg {
+    /// Whether or not to generate new keys for a handshake.
+    pub generate_new_keys: bool,
+
+    /// Handshake configuration.
+    ///
+    /// If not set, the handshake will be skipped.
+    pub handshake: Option<HandshakeCfg>,
+
+    /// Pea2Pea configuration.
     pub pea2pea_config: pea2pea::Config,
 }
 
-impl Default for TestConfig {
+impl Default for SynthNodeCfg {
     fn default() -> Self {
         let ip_addr = IpAddr::V4(Ipv4Addr::LOCALHOST);
         Self {
-            synth_node_config: Default::default(),
+            generate_new_keys: true,
+            handshake: Some(Default::default()),
             pea2pea_config: pea2pea::Config {
                 listener_ip: Some(ip_addr),
                 ..Default::default()
             },
-        }
-    }
-}
-
-impl TestConfig {
-    pub fn with_handshake(mut self, handshake: bool) -> Self {
-        self.synth_node_config.do_handshake = handshake;
-        self
-    }
-
-    pub fn with_initial_message(mut self, payload: Payload) -> Self {
-        self.synth_node_config.initial_message = Some(payload);
-        self
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntheticNodeTestConfig {
-    /// Whether or not to call `enable_handshake` when creating a new node
-    pub do_handshake: bool,
-    /// Initial message to be sent to real node
-    pub initial_message: Option<Payload>,
-    /// Whether or not to generate new keys for a handshake.
-    pub generate_new_keys: bool,
-    /// Identification header to be set during a handshake. Either 'User-Agent' or 'Server' depending on connection side.
-    pub ident: String,
-    /// Will flip random bit in a random byte of shared value used for session signing.
-    pub handshake_bit_flip_shared_val: bool,
-    /// Will flip random bit in a random byte of the public key.
-    pub handshake_bit_flip_pub_key: bool,
-}
-
-impl Default for SyntheticNodeTestConfig {
-    fn default() -> Self {
-        Self {
-            do_handshake: true,
-            initial_message: None,
-            generate_new_keys: true,
-            ident: "rippled-1.9.1".into(),
-            handshake_bit_flip_shared_val: false,
-            handshake_bit_flip_pub_key: false,
         }
     }
 }

--- a/src/tools/synth_node.rs
+++ b/src/tools/synth_node.rs
@@ -21,7 +21,7 @@ use crate::{
         writing::MessageOrBytes,
     },
     tools::{
-        config::TestConfig,
+        config::SynthNodeCfg,
         constants::{EXPECTED_RESULT_TIMEOUT, SYNTH_NODE_QUEUE_DEPTH},
         inner_node::InnerNode,
     },
@@ -43,14 +43,16 @@ pub struct SyntheticNode {
 }
 
 impl SyntheticNode {
-    pub async fn new(config: &TestConfig) -> Self {
+    pub async fn new(config: &SynthNodeCfg) -> Self {
         let (sender, receiver) = mpsc::channel(SYNTH_NODE_QUEUE_DEPTH);
         let inner = InnerNode::new(config, sender).await;
-        if config.synth_node_config.do_handshake {
+
+        if config.handshake.is_some() {
             inner.enable_handshake().await;
         }
         inner.enable_reading().await;
         inner.enable_writing().await;
+
         Self { inner, receiver }
     }
 


### PR DESCRIPTION
TestConfig used to be an input for some conformance tests and also for a SyntheticNode creation. Now, it's decoupled:
- SyntNodeCfg ---> creation of the SyntheticNode
- TestConfig ---> used only for a test configuration (in conformance)

Also - the Handshake config has been moved to src/protocol/ and is used in both InnerNode and SyntNodeCfg.
Duplicated InnerNodeCfg handshake elements have been removed.