### PR TITLE
feat: crawler workflow

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,4 +1,4 @@
-name: rippled
+name: crawler
 
 on:
   schedule:
@@ -35,6 +35,16 @@ jobs:
           cd build
           cmake ..
           cmake --build .
+      - name: Configure rippled
+        run: |
+          mkdir -p ~/.config/ripple
+          cp rippled/cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
+          cp rippled/cfg/validators-example.txt ~/.config/ripple/validators.txt
+      - name: Test-run rippled
+        run: |
+          chmod +x rippled/build/rippled
+          ./rippled/build/rippled &
+          sleep 5m
       - uses: actions/upload-artifact@v3
         with:
           name: rippled-executable
@@ -73,6 +83,6 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git pull
-          git add results
+          git add ./
           git commit -m "ci: crawler results"
           git push

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -65,23 +65,33 @@ jobs:
         run: |
           chmod +x rippled/rippled
           ./rippled/rippled &
-          cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
+          cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:51235 --rpc-addr 127.0.0.1:54321 &
           mkdir -p results/crawler
           rm -f results/crawler/latest.json
           # After 30 min, query rpc and send SIGINT.
           sleep 30m
-          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
+          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": { "file": "latest.json" } }' -H 'content-type: application/json' http://127.0.0.1:54321/
           kill -2 $(pidof crawler) $(pidof rippled)
-          cat results/crawler/latest.json
-      - name: Git
+      - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)
+          cat latest.json
+          # If the result contains any error, fail workflow
+          if grep "error" latest.json; then
+            echo "Aborting. Crawler results contained an error"
+            exit 1
+          fi
+          mkdir -p results/crawler
+          rm -f results/crawler/latest.json
+          mv latest.json results/crawler/latest.json
           cd results/crawler
           cp latest.json $FILENAME.json
           gzip $FILENAME.json
+      - name: Git
+        run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git pull
-          git add ./
+          git add results/crawler
           git commit -m "ci: crawler results"
           git push

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -3,9 +3,6 @@ name: crawler
 on:
   schedule:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
-  push:
-    branches:
-      - crawler-ci
 
 jobs:
   install-rippled:
@@ -66,12 +63,10 @@ jobs:
           chmod +x rippled/rippled
           ./rippled/rippled &
           cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:51235 --rpc-addr 127.0.0.1:54321 &
-          mkdir -p results/crawler
-          rm -f results/crawler/latest.json
-          # After 30 min, query rpc and send SIGINT.
+          # After 30 min, query rpc and send SIGTERM.
           sleep 30m
           curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": { "file": "latest.json" } }' -H 'content-type: application/json' http://127.0.0.1:54321/
-          kill -2 $(pidof crawler) $(pidof rippled)
+          kill $(pidof crawler) $(pidof rippled)
       - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -35,56 +35,53 @@ jobs:
           cd build
           cmake ..
           cmake --build .
-      - name: Configure rippled
-        run: |
-          mkdir -p ~/.config/ripple
-          cp rippled/cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
-          cp rippled/cfg/validators-example.txt ~/.config/ripple/validators.txt
-          sed -i 's#^path=/var/lib/rippled/db/nudb#path=/home/runner/work/rippled/rippled/db/nudb#' ~/.config/ripple/rippled.cfg
-          sed -i 's#^/var/lib/rippled/db#/home/runner/work/rippled/rippled/db#' ~/.config/ripple/rippled.cfg
-      - name: Test-run rippled
-        run: |
-          chmod +x rippled/build/rippled
-          ./rippled/build/rippled &
-          sleep 5m
       - uses: actions/upload-artifact@v3
         with:
           name: rippled-executable
           path: ./rippled/build/rippled
 
-  # crawl-network:
-  #   runs-on: ubuntu-latest
-  #   needs: [ install-rippled ]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - run: rustup toolchain install stable --profile minimal
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: rippled-executable
-  #         path: ./rippled
-  #     - name: Begin crawling
-  #       run: |
-  #         chmod +x rippled/rippled
-  #         ./rippled/rippled &
-  #         cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
-  #         mkdir -p results/crawler
-  #         rm -f results/crawler/latest.json
-  #         # After 30 min, query rpc and send SIGINT.
-  #         sleep 30m
-  #         curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
-  #         kill -2 $(pidof crawler) $(pidof rippled)
-  #         cat results/crawler/latest.json
-  #     - name: Git
-  #       run: |
-  #         FILENAME=$(date +%Y-%m-%d)
-  #         cd results/crawler
-  #         cp latest.json $FILENAME.json
-  #         gzip $FILENAME.json
-  #         git config user.name 'github-actions[bot]'
-  #         git config user.email 'github-actions[bot]@users.noreply.github.com'
-  #         git pull
-  #         git add ./
-  #         git commit -m "ci: crawler results"
-  #         git push
+  crawl-network:
+    runs-on: ubuntu-latest
+    needs: [ install-rippled ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: rustup toolchain install stable --profile minimal
+      - name: Configure rippled
+        run: |
+          git clone https://github.com/XRPLF/rippled
+          mkdir -p ~/.config/ripple
+          cp rippled/cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
+          cp rippled/cfg/validators-example.txt ~/.config/ripple/validators.txt
+          sed -i 's#^path=/var/lib/rippled/db/nudb#path=/home/runner/work/rippled/rippled/db/nudb#' ~/.config/ripple/rippled.cfg
+          sed -i 's#^/var/lib/rippled/db#/home/runner/work/rippled/rippled/db#' ~/.config/ripple/rippled.cfg
+          sed -i 's#^/var/log/rippled/debug.log#/home/runner/work/rippled/rippled/debug.log#' ~/.config/ripple/rippled.cfg
+      - uses: actions/download-artifact@v3
+        with:
+          name: rippled-executable
+          path: ./rippled
+      - name: Begin crawling
+        run: |
+          chmod +x rippled/rippled
+          ./rippled/rippled &
+          cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
+          mkdir -p results/crawler
+          rm -f results/crawler/latest.json
+          # After 30 min, query rpc and send SIGINT.
+          sleep 30m
+          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
+          kill -2 $(pidof crawler) $(pidof rippled)
+          cat results/crawler/latest.json
+      - name: Git
+        run: |
+          FILENAME=$(date +%Y-%m-%d)
+          cd results/crawler
+          cp latest.json $FILENAME.json
+          gzip $FILENAME.json
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull
+          git add ./
+          git commit -m "ci: crawler results"
+          git push

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -1,0 +1,78 @@
+name: rippled
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
+  push:
+    branches:
+      - crawler-ci
+
+jobs:
+  install-rippled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen
+          wget https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh
+          sudo sh cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+      - name: Compile boost
+        run: |
+          wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
+          tar xvzf boost_1_75_0.tar.gz
+          cd boost_1_75_0
+          ./bootstrap.sh
+          ./b2 -j $(nproc)
+      - name: Clone and build rippled
+        env:
+          BOOST_ROOT: /home/runner/work/xrpl/xrpl/boost_1_75_0
+        run: |
+          git clone https://github.com/XRPLF/rippled
+          cd rippled
+          git checkout master
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rippled-executable
+          path: ./rippled/build/rippled
+
+  crawl-network:
+    runs-on: ubuntu-latest
+    needs: [ install-rippled ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: rustup toolchain install stable --profile minimal
+      - uses: actions/download-artifact@v3
+        with:
+          name: rippled-executable
+          path: ./rippled
+      - name: Begin crawling
+        run: |
+          chmod +x rippled/rippled
+          ./rippled/rippled &
+          cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
+          mkdir -p results/crawler
+          rm -f results/crawler/latest.json
+          # After 30 min, query rpc and send SIGINT.
+          sleep 30m
+          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
+          kill -2 $(pidof crawler) $(pidof rippled)
+          cat results/crawler/latest.json
+      - name: Git
+        run: |
+          FILENAME=$(date +%Y-%m-%d)
+          cd results/crawler
+          cp latest.json $FILENAME.json
+          gzip $FILENAME.json
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git pull
+          git add results
+          git commit -m "ci: crawler results"
+          git push

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -40,6 +40,8 @@ jobs:
           mkdir -p ~/.config/ripple
           cp rippled/cfg/rippled-example.cfg ~/.config/ripple/rippled.cfg
           cp rippled/cfg/validators-example.txt ~/.config/ripple/validators.txt
+          sed -i 's#^path=/var/lib/rippled/db/nudb#path=/home/runner/work/rippled/rippled/db/nudb#' ~/.config/ripple/rippled.cfg
+          sed -i 's#^/var/lib/rippled/db#/home/runner/work/rippled/rippled/db#' ~/.config/ripple/rippled.cfg
       - name: Test-run rippled
         run: |
           chmod +x rippled/build/rippled
@@ -50,39 +52,39 @@ jobs:
           name: rippled-executable
           path: ./rippled/build/rippled
 
-  crawl-network:
-    runs-on: ubuntu-latest
-    needs: [ install-rippled ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: rustup toolchain install stable --profile minimal
-      - uses: actions/download-artifact@v3
-        with:
-          name: rippled-executable
-          path: ./rippled
-      - name: Begin crawling
-        run: |
-          chmod +x rippled/rippled
-          ./rippled/rippled &
-          cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
-          mkdir -p results/crawler
-          rm -f results/crawler/latest.json
-          # After 30 min, query rpc and send SIGINT.
-          sleep 30m
-          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
-          kill -2 $(pidof crawler) $(pidof rippled)
-          cat results/crawler/latest.json
-      - name: Git
-        run: |
-          FILENAME=$(date +%Y-%m-%d)
-          cd results/crawler
-          cp latest.json $FILENAME.json
-          gzip $FILENAME.json
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git pull
-          git add ./
-          git commit -m "ci: crawler results"
-          git push
+  # crawl-network:
+  #   runs-on: ubuntu-latest
+  #   needs: [ install-rippled ]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - run: rustup toolchain install stable --profile minimal
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: rippled-executable
+  #         path: ./rippled
+  #     - name: Begin crawling
+  #       run: |
+  #         chmod +x rippled/rippled
+  #         ./rippled/rippled &
+  #         cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:5005 --rpc-addr 127.0.0.1:54321 &
+  #         mkdir -p results/crawler
+  #         rm -f results/crawler/latest.json
+  #         # After 30 min, query rpc and send SIGINT.
+  #         sleep 30m
+  #         curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > results/crawler/latest.json
+  #         kill -2 $(pidof crawler) $(pidof rippled)
+  #         cat results/crawler/latest.json
+  #     - name: Git
+  #       run: |
+  #         FILENAME=$(date +%Y-%m-%d)
+  #         cd results/crawler
+  #         cp latest.json $FILENAME.json
+  #         gzip $FILENAME.json
+  #         git config user.name 'github-actions[bot]'
+  #         git config user.email 'github-actions[bot]@users.noreply.github.com'
+  #         git pull
+  #         git add ./
+  #         git commit -m "ci: crawler results"
+  #         git push

--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -65,7 +65,7 @@ jobs:
           cargo run --features crawler --bin crawler -- --seed-addrs 127.0.0.1:51235 --rpc-addr 127.0.0.1:54321 &
           # After 30 min, query rpc and send SIGTERM.
           sleep 30m
-          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": { "file": "latest.json" } }' -H 'content-type: application/json' http://127.0.0.1:54321/
+          curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "dumpmetrics", "params": { "file": "latest.json" } }' -H 'content-type: application/json' http://127.0.0.1:54321/
           kill $(pidof crawler) $(pidof rippled)
       - name: Process results
         run: |


### PR DESCRIPTION
This PR introduces a new workflow that will:

1. Compile a `rippled` node from source
2. Crawl the network, using the built node as the entry point
3. Produce network metrics under the `results/crawler` directory.