### PR TITLE
feat(ci): display diff from last run

### DIFF
--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -93,18 +93,41 @@ jobs:
           mv ./ziggurat/ziggurat_* ziggurat_test
           chmod +x ziggurat_test
           mkdir -p results/rippled
-          rm -f results/rippled/latest.jsonl
+          mv results/rippled/latest.jsonl results/rippled/comparison.jsonl
           ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > results/rippled/latest.jsonl
           cat results/rippled/latest.jsonl
-      - name: Git
+      - name: Process results
         run: |
           FILENAME=$(date +%Y-%m-%d)
           cd results/rippled
           cp latest.jsonl $FILENAME.jsonl
+          gzip $FILENAME.jsonl
+      - name: Compare results
+        run: |
+          # Helper function to remove ignored tests and started ones, and then attributes exec_time and type
+          filter_json() {
+            tmp=$(mktemp)
+            ! jq 'del(select(.event == "ignored"))' $1 > $tmp && mv $tmp $1 # Remove ignored tests
+            jq 'del(select(.event == "started"))' $1 > $tmp && mv $tmp $1 # Remove started tests
+            jq 'del(.exec_time) | del(.type)' $1 > $tmp && mv $tmp $1 # Remove exec_time and type attributes
+            # Remove null characters and empty lines
+            sed -i 's/null//g' $1
+            sed -i '/^$/d' $1
+          }
+          mkdir temp
+          cp results/rippled/latest.jsonl temp/
+          mv results/rippled/comparison.jsonl temp/
+          cd temp
+          filter_json latest.jsonl
+          filter_json comparison.jsonl
+          ! diff -u comparison.jsonl latest.jsonl
+          cd ..
+          rm -rf temp
+      - name: Git
+        run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          gzip $FILENAME.jsonl
           git pull
-          git add ./
+          git add results/rippled
           git commit -m "ci: rippled suite results"
           git push


### PR DESCRIPTION
Included with this PR:
- A new step that will display the output of the `diff` command between the workflows latest run (`latest.jsonl`) and the one prior to that (`comparison.jsonl`)
- The json files are modified in a new function, `filter_json`, to filter out things that would clog the output of `diff`, e.g `exec_time` and `type`.