### PR TITLE
fix: update rippled build

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -10,28 +10,26 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen
+          pip install -Iv conan==1.59.0
           wget https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh
           sudo sh cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
-      - name: Compile boost
-        run: |
-          wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
-          tar xvzf boost_1_75_0.tar.gz
-          cd boost_1_75_0
-          ./bootstrap.sh
-          ./b2 -j $(nproc)
-      - name: Clone and build rippled
-        env:
-          BOOST_ROOT: /home/runner/work/xrpl/xrpl/boost_1_75_0
+      - name: Clone rippled and set up conan
         run: |
           git clone https://github.com/XRPLF/rippled
           cd rippled
           git checkout master
+          conan profile new default --detect
+          conan profile update settings.compiler.cppstd=20 default
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+      - name: Build rippled
+        run: |
+          cd rippled
+          conan export external/snappy snappy/1.1.9@
           mkdir build
           cd build
-          cmake ..
-          cmake --build .
+          conan install .. --output-folder . --build missing --settings build_type=Release
+          cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build . -j $(nproc)
       - uses: actions/upload-artifact@v3
         with:
           name: rippled-executable

--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -10,28 +10,26 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen
+          pip install -Iv conan==1.59.0
           wget https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh
           sudo sh cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
-      - name: Compile boost
-        run: |
-          wget https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
-          tar xvzf boost_1_75_0.tar.gz
-          cd boost_1_75_0
-          ./bootstrap.sh
-          ./b2 -j $(nproc)
-      - name: Clone and build rippled
-        env:
-          BOOST_ROOT: /home/runner/work/xrpl/xrpl/boost_1_75_0
+      - name: Clone rippled and set up conan
         run: |
           git clone https://github.com/XRPLF/rippled
           cd rippled
           git checkout master
+          conan profile new default --detect
+          conan profile update settings.compiler.cppstd=20 default
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+      - name: Build rippled
+        run: |
+          cd rippled
+          conan export external/snappy snappy/1.1.9@
           mkdir build
           cd build
-          cmake ..
-          cmake --build .
+          conan install .. --output-folder . --build missing --settings build_type=Release
+          cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build . -j $(nproc)
       - uses: actions/upload-artifact@v3
         with:
           name: rippled-executable


### PR DESCRIPTION
With the new `rippled 1.10.0` release, the build process has changed significantly. This PR updates our workflow to build `rippled` correctly following the new [guidelines](https://github.com/XRPLF/rippled/blob/master/BUILD.md) .