### PR TITLE
chore(dev): link crawl.rs with the CPR suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.21.0"
 bytes = "1"
+chrono = "0.4"
 fs_extra = "1.2"
 governor = "0.5.1"
 hex = "0.4"
@@ -25,6 +26,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 tabled = "0.10"
 tempfile = "3.3"
+thiserror = "1.0"
 tokio-openssl = "0.6"
 toml = "0.5.9"
 ziggurat-core-metrics = { git = "https://github.com/runziggurat/ziggurat-core", tag = "v0.1.2-zgm" }
@@ -70,8 +72,9 @@ features = ["global-context", "rand-std"]
 version = "1"
 features = ["derive"]
 
-[dependencies.thiserror]
-version = "1"
+[dependencies.spectre]
+git = "https://github.com/niklaslong/spectre"
+rev = "9a0664f"
 optional = true
 
 [dependencies.tokio]
@@ -91,18 +94,13 @@ version = "0.3"
 default-features = false
 features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"]
 
-[dependencies.spectre]
-git = "https://github.com/niklaslong/spectre"
-rev = "9a0664f"
-optional = true
-
 [dependencies.ziggurat-core-crawler]
 git = "https://github.com/runziggurat/ziggurat-core"
 rev = "1a5c2e2"
 optional = true
 
 [features]
-crawler = ["clap", "thiserror", "jsonrpsee", "spectre", "ziggurat-core-crawler"]
+crawler = ["clap", "jsonrpsee", "spectre", "ziggurat-core-crawler"]
 performance = []
 
 [[bin]]

--- a/src/tests/idle_node_in_the_background.rs
+++ b/src/tests/idle_node_in_the_background.rs
@@ -36,11 +36,8 @@ enum NodeLogToStdout {
 }
 
 impl NodeLogToStdout {
-    fn is_on(self) -> bool {
-        match self {
-            NodeLogToStdout::Off => false,
-            _ => true,
-        }
+    fn is_on(&self) -> bool {
+        matches!(self, NodeLogToStdout::On)
     }
 }
 
@@ -105,8 +102,10 @@ async fn dev001_t1_RUN_NODE_FOREVER_with_logs() {
 async fn dev001_t2_RUN_NODE_FOREVER_no_logs() {
     // This test is used for testing/development purposes.
 
-    let mut cfg = DevTestCfg::default();
-    cfg.crawl = PeriodicCrawlOpt::On(Duration::from_secs(2));
+    let cfg = DevTestCfg {
+        crawl: PeriodicCrawlOpt::On(Duration::from_secs(2)),
+        ..Default::default()
+    };
     node_run_forever(cfg).await;
 
     panic!("the node shouldn't have died");
@@ -118,9 +117,11 @@ async fn dev001_t2_RUN_NODE_FOREVER_no_logs() {
 async fn dev002_t1_MONITOR_NODE_FOREVER_WITH_SYNTH_NODE_sn_is_conn_initiator() {
     // This test is used for testing/development purposes.
 
-    let mut cfg = DevTestCfg::default();
-    cfg.crawl = PeriodicCrawlOpt::On(Duration::from_secs(3));
-    cfg.synth_node = SynthNodeOpt::On_TryToConnect(SynthNodeCfg::default());
+    let cfg = DevTestCfg {
+        crawl: PeriodicCrawlOpt::On(Duration::from_secs(3)),
+        synth_node: SynthNodeOpt::On_TryToConnect(SynthNodeCfg::default()),
+        ..Default::default()
+    };
     node_run_forever(cfg).await;
 
     panic!("the node shouldn't have died");
@@ -132,11 +133,12 @@ async fn dev002_t1_MONITOR_NODE_FOREVER_WITH_SYNTH_NODE_sn_is_conn_initiator() {
 async fn dev002_t2_MONITOR_NODE_FOREVER_WITH_SYNTH_NODE_sn_is_conn_responder() {
     // This test is used for testing/development purposes.
 
-    let mut cfg = DevTestCfg::default();
-    cfg.log_to_stdout = NodeLogToStdout::On;
-    cfg.tracing = TracingOpt::On;
-    cfg.crawl = PeriodicCrawlOpt::On(Duration::from_secs(5));
-    cfg.synth_node = SynthNodeOpt::On_OnlyListening(SynthNodeCfg::default());
+    let cfg = DevTestCfg {
+        log_to_stdout: NodeLogToStdout::On,
+        tracing: TracingOpt::On,
+        crawl: PeriodicCrawlOpt::On(Duration::from_secs(5)),
+        synth_node: SynthNodeOpt::On_OnlyListening(SynthNodeCfg::default()),
+    };
     node_run_forever(cfg).await;
 
     panic!("the node shouldn't have died");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod conformance;
+mod idle_node_in_the_background;
 mod performance;
 mod resistance;

--- a/src/tools/crawl.rs
+++ b/src/tools/crawl.rs
@@ -1,0 +1,1 @@
+crawler/crawl.rs

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,11 @@
 
 pub mod config;
 pub mod constants;
+// This mod belongs to the tools/crawler and we are using a sym
+// link to get it here.
+// This is a workaround solution in this repo for this case,
+// in future Ziggurat repos, we will handle this differently.
+pub mod crawl;
 pub mod inner_node;
 pub mod ips;
 pub mod rpc;


### PR DESCRIPTION
- dev tests in `idle_node_in_the_background.rs` use a crawler mechanism for easier analysis of the node behavior. For that reason existing crawl.rs is reused from the crawler binary.

  A quick solution is used here - instead of making a clean copy of the file, or even moving it out from the binary directory, we are just reusing it with a symlink. In future Ziggurat projects, this shall be handled in a different fasion.