### PR TITLE
docs: add deps.rs badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![dependency status](https://deps.rs/repo/github/runziggurat/xrpl/status.svg)](https://deps.rs/repo/github/runziggurat/xrpl)
+
 # Ziggurat x XRPL
 
 The Ziggurat implementation for XRPLF's `rippled` nodes.


### PR DESCRIPTION
Improvement Bucket Task: `Add deps.rs badges to all our readme documents`