### PR TITLE
chore: add workflow badge, move both badges below title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![dependency status](https://deps.rs/repo/github/runziggurat/xrpl/status.svg)](https://deps.rs/repo/github/runziggurat/xrpl)
-
 # Ziggurat x XRPL
+[![dependency status](https://deps.rs/repo/github/runziggurat/xrpl/status.svg)](https://deps.rs/repo/github/runziggurat/xrpl)
+![workflow status](https://github.com/runziggurat/xrpl/actions/workflows/rippled.yml/badge.svg)
 
 The Ziggurat implementation for XRPLF's `rippled` nodes.
 


### PR DESCRIPTION
extension of the Improvement Bucket Task: `Add deps.rs badges to all our readme documents`
- added workflow CI badge
- moved badges below title