### PR TITLE
ref: call workflows under `ziggurat-core`

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -53,7 +53,7 @@ jobs:
 
   call-process-results-workflow:
     needs: [ crawl-network ]
-    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
     with:
       name: crawler
       extension: json

--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -9,7 +9,7 @@ jobs:
     uses: runziggurat/xrpl/.github/workflows/build-rippled.yml@main
 
   call-build-ziggurat-workflow:
-    uses: runziggurat/zcash/.github/workflows/build-ziggurat.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/build-ziggurat.yml@main
     with:
       extra-args: --features performance
 
@@ -70,10 +70,10 @@ jobs:
 
   call-process-results-workflow:
     needs: [ test-rippled ]
-    uses: runziggurat/zcash/.github/workflows/process-results.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
     with:
       name: rippled
 
   call-diff-with-previous-workflow:
     needs: [ test-rippled ]
-    uses: runziggurat/zcash/.github/workflows/diff-with-previous.yml@main
+    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main


### PR DESCRIPTION
Call the new shared workflows under the `ziggurat-core` repo.