### PR TITLE
chore: move detailed IPS/performance docs into separate readme

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -1,0 +1,34 @@
+## Run performance tests
+Create a package of IP addresses which are required for performance tests.
+
+You must first fetch the `ips.py` script from the ziggurat-core repository.  Run this:
+
+```bash
+wget -O tools/ips.py https://raw.githubusercontent.com/runziggurat/ziggurat-core/main/ziggurat-core-scripts/ips.py
+```
+
+_NOTE: To run the `ips.py` script below, the user must be in the sudoers file in order to use this script.
+Script uses `ip`/`ipconfig` commands which require sudo privilages._
+
+From the root repository directory, depending on your OS, run one of the following commands.
+
+### Preconditions under Linux
+Generate dummy devices with addresses:
+```bash
+python3 ./tools/ips.py --subnet 1.1.1.0/24 --file tools/ips_list.json --dev_prefix test_zeth
+```
+
+### Preconditions under MacOS
+Add the whole subnet to the loopback device - can also be used on Linux (device name - Linux: `lo`, MacOS: `lo0`):
+```bash
+python3 ./tools/ips.py --subnet 1.1.0.0/24 --file tools/ips_list.json --dev lo0
+```
+
+Read ./tools/ips.py for more details.
+
+### Run tests
+Run performance tests with the following command:
+```bash
+cargo +stable t performance --features performance -- --test-threads=1
+```
+

--- a/README.md
+++ b/README.md
@@ -59,39 +59,10 @@ Run conformance and resistance tests with the following command:
 ```bash
 cargo +stable t -- --test-threads=1
 ```
-### Run performance tests
-Create a package of IP addresses which are required for performance tests.
 
-You must first fetch the `ips.py` script from the ziggurat-core repository.  Run this:
+## Run performance tests
 
-```bash
-wget -O tools/ips.py https://raw.githubusercontent.com/runziggurat/ziggurat-core/main/ziggurat-core-scripts/ips.py
-```
-
-_NOTE: To run the `ips.py` script below, the user must be in the sudoers file in order to use this script.
-Script uses `ip`/`ipconfig` commands which require sudo privilages._
-
-From the root repository directory, depending on your OS, run one of the following commands.
-
-#### Preconditions under Linux
-Generate dummy devices with addresses:
-```bash
-python3 ./tools/ips.py --subnet 1.1.1.0/24 --file tools/ips_list.json --dev_prefix test_zeth
-```
-
-#### Preconditions under MacOS
-Add the whole subnet to the loopback device - can also be used on Linux (device name - Linux: `lo`, MacOS: `lo0`):
-```bash
-python3 ./tools/ips.py --subnet 1.1.0.0/24 --file tools/ips_list.json --dev lo0
-```
-
-Read ./tools/ips.py for more details.
-
-#### Run tests
-Run performance tests with the following command:
-```bash
-cargo +stable t performance --features performance -- --test-threads=1
-```
+Consult the [performance tests readme](PERF.md) for details on running these tests.
 
 ## Test status
 


### PR DESCRIPTION
Last of a series of PRs related to these three improvement bucket list items
- How to share common scripts across different repos
- Think how to avoid having modified file in the repo after running the script
- Move the ips.py script to some common place for scripts in ziggurat-core

This PR duplicates the linked readme structure recently created for algorand.