### PR TITLE
ci: remove `diff-with-previous` step

### DIFF
--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -73,12 +73,3 @@ jobs:
       repository: xrpl
     secrets:
       gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}
-
-  call-diff-with-previous-workflow:
-    needs: [ test-rippled ]
-    uses: runziggurat/ziggurat-core/.github/workflows/diff-with-previous.yml@main
-    with:
-      name: rippled
-      repository: xrpl
-    secrets:
-      gcp_credentials: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
Diffing is handled easier in the GUI, thus we remove this step from the workflows.