### PR TITLE
Grab node metadata

### DIFF
--- a/.github/workflows/build-rippled.yml
+++ b/.github/workflows/build-rippled.yml
@@ -1,9 +1,14 @@
 on:
   workflow_call:
+    outputs:
+      commit-hash:
+        value: ${{ jobs.build-rippled.outputs.commit-hash }}
 
 jobs:
   build-rippled:
     runs-on: ubuntu-latest
+    outputs:
+      commit-hash: ${{ steps.commit-hash.outputs.commit-hash }}
     steps:
       - name: Install dependencies
         run: |
@@ -14,6 +19,9 @@ jobs:
         with:
           repository: XRPLF/rippled
           ref: develop
+      - name: Grab short commit hash and store in env
+        id: commit-hash
+        run: echo commit-hash=$(git log -n 1 --pretty=format:"%h") >> "$GITHUB_OUTPUT"
       - name: Set up conan
         run: |
           conan profile new default --detect

--- a/.github/workflows/build-rippled.yml
+++ b/.github/workflows/build-rippled.yml
@@ -10,17 +10,17 @@ jobs:
           pip install -Iv conan==1.59.0
           wget https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh
           sudo sh cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
-      - name: Clone rippled and set up conan
+      - uses: actions/checkout@v3
+        with:
+          repository: XRPLF/rippled
+          ref: develop
+      - name: Set up conan
         run: |
-          git clone https://github.com/XRPLF/rippled
-          cd rippled
-          git checkout master
           conan profile new default --detect
           conan profile update settings.compiler.cppstd=20 default
           conan profile update settings.compiler.libcxx=libstdc++11 default
       - name: Build rippled
         run: |
-          cd rippled
           conan export external/snappy snappy/1.1.9@
           mkdir build
           cd build
@@ -29,5 +29,5 @@ jobs:
           cmake --build . -j $(nproc)
       - uses: actions/upload-artifact@v3
         with:
-          name: rippled-executable
-          path: ./rippled/build/rippled
+          name: node-executable
+          path: ./build/rippled

--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -47,6 +47,7 @@ jobs:
         uses: runziggurat/ziggurat-core@main
         with:
           node-name: rippled
+          commit-hash: ${{ needs.build-rippled.outputs.commit-hash }}
 
   call-process-results-workflow:
     needs: [ run-test-suite ]

--- a/.github/workflows/rippled.yml
+++ b/.github/workflows/rippled.yml
@@ -6,33 +6,23 @@ on:
     - cron: '0 6 * * *' # Every day at 6:00 AM UTC.
 
 jobs:
-  call-build-rippled-workflow:
+  build-rippled:
     uses: runziggurat/xrpl/.github/workflows/build-rippled.yml@main
 
-  call-build-ziggurat-workflow:
+  build-ziggurat:
     uses: runziggurat/ziggurat-core/.github/workflows/build-ziggurat.yml@main
     with:
       extra-args: --features performance
 
-  test-rippled:
+  run-test-suite:
     runs-on: ubuntu-latest
-    needs: [ call-build-ziggurat-workflow, call-build-rippled-workflow ]
+    needs: [ build-rippled, build-ziggurat ]
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - run: rustup toolchain install stable --profile minimal
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
       - uses: actions/download-artifact@v3
         with:
-          name: rippled-executable
+          name: node-executable
           path: ./rippled
-      - uses: actions/download-artifact@v3
-        with:
-          name: ziggurat-executable
-          path: ./ziggurat
       - name: Enable openSSL legacy functions
         run: |
           cp /etc/ssl/openssl.cnf ./
@@ -53,20 +43,13 @@ jobs:
         run: |
           wget -O tools/ips.py https://raw.githubusercontent.com/runziggurat/ziggurat-core/main/ziggurat-core-scripts/ips.py
           python3 ./tools/ips.py --subnet 1.1.0.0/24 --file tools/ips_list.json --dev lo
-      - name: Run ziggurat suite
-        continue-on-error: true
-        run: |
-          rm ./ziggurat/*.d
-          mv ./ziggurat/ziggurat_* ziggurat_test
-          chmod +x ziggurat_test
-          ./ziggurat_test --test-threads=1 --nocapture -Z unstable-options --report-time --format json > latest.jsonl
-      - uses: actions/upload-artifact@v3
+      - name: Run Ziggurat test suite
+        uses: runziggurat/ziggurat-core@main
         with:
-          name: latest-result
-          path: latest.jsonl
+          node-name: rippled
 
   call-process-results-workflow:
-    needs: [ test-rippled ]
+    needs: [ run-test-suite ]
     uses: runziggurat/ziggurat-core/.github/workflows/process-results.yml@main
     with:
       name: rippled


### PR DESCRIPTION
- Implements runziggurat/ziggurat-core#52
- `rippled` is now built from the latest commit on `develop` instead of `master`.